### PR TITLE
Comment and semicolon changes to missing_table_stats.sql

### DIFF
--- a/src/AdminScripts/README.md
+++ b/src/AdminScripts/README.md
@@ -9,6 +9,6 @@ If you are using psql, you can use \i &lt;script.sql&gt; to run.
 | filter_used.sql | Return filter applied to tables on scans. To aid on choosing sortkey |
 | commit_stats.sql | Shows information on consumption of cluster resources through COMMIT statements |
 | current_session_info.sql | Query showing information about sessions with currently running queries |
-| missing_table_stats.sql | Query show explain plans which flagged missing statistics on underlying tables |
+| missing_table_stats.sql | Query shows EXPLAIN plans which flagged "missing statistics" on the underlying tables |
 | queuing_queries.sql | Query showing queries which are waiting on a WLM Query Slot |
 | table_info.sql | Return Table storage information (size, skew, etc) |

--- a/src/AdminScripts/missing_table_stats.sql
+++ b/src/AdminScripts/missing_table_stats.sql
@@ -1,7 +1,7 @@
-/* Query show explain plans which flagged missing statistics on underlying tables */
+/* Query shows explain plans which flagged "missing statistics" on underlying tables */
 SELECT substring(trim(plannode),1,100) AS plannode
        ,COUNT(*)
 FROM stl_explain
 WHERE plannode LIKE '%missing statistics%'
 GROUP BY plannode
-ORDER BY 2 DESC
+ORDER BY 2 DESC;

--- a/src/AdminScripts/missing_table_stats.sql
+++ b/src/AdminScripts/missing_table_stats.sql
@@ -1,4 +1,4 @@
-/* Query shows explain plans which flagged "missing statistics" on underlying tables */
+/* Query shows EXPLAIN plans which flagged "missing statistics" on the underlying tables */
 SELECT substring(trim(plannode),1,100) AS plannode
        ,COUNT(*)
 FROM stl_explain


### PR DESCRIPTION
Changed the comment to be clearer.
Added a semi-colon at the end of the script.