### PR TITLE
Add support for PG* environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,61 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Virtual environments
+venv/
+.venv/


### PR DESCRIPTION
Sample output:
```bash
# With environment variables set
$ envcrypt ~/.secrets/redshift-dev.gpg ./analyze-schema-compression.py --analyze-table data_tran_codes --output-file out.txt
-- [31889] Connected to xxx.redshift.amazonaws.com:5439:analytics as jklukas
-- [31889] Analyzing Table 'data_tran_codes' for Columnar Encoding Optimisations with 1 Threads...
-- [31889] Analyzing 0 table(s)
-- [31889] Processing Complete

# Without environment variables set
› ./analyze-schema-compression.py --analyze-table data_tran_codes --output-file out.txt
Usage: analyze-schema-compression.py
       Generates a script to optimise Redshift column encodings on all tables in a schema

Missing Parameter 'db'

Arguments: --db             - The Database to Use (default $PGDATABASE)
           --db-user        - The Database User to connect to (default $PGUSER)
           --db-host        - The Cluster endpoint (default $PGHOST)
           --db-port        - The Cluster endpoint port (default $PGPORT or 5439)
           --analyze-schema - The Schema to be Analyzed (default public)
           --analyze-table  - A specific table to be Analyzed, if --analyze-schema is not desired
           --target-schema  - Name of a Schema into which the newly optimised tables and data should be created, rather than in place
           --threads        - The number of concurrent connections to use during analysis (default 2)
           --output-file    - The full path to the output file to be generated
           --debug          - Generate Debug Output including SQL Statements being run
           --do-execute     - Run the compression encoding optimisation
           --slot-count     - Modify the wlm_query_slot_count from the default of 1
           --ignore-errors  - Ignore errors raised in threads when running and continue processing
           --force          - Force table migration even if the table already has Column Encoding applied
           --drop-old-data  - Drop the old version of the data table, rather than renaming
           --comprows       - Set the number of rows to use for Compression Encoding Analysis
           --query_group    - Set the query_group for all queries
```