### PR TITLE
Fix v_check_data_distribution.total_rowcount

### DIFF
--- a/src/AdminViews/v_check_data_distribution.sql
+++ b/src/AdminViews/v_check_data_distribution.sql
@@ -13,7 +13,7 @@ SELECT
 	,id AS tbl_oid
 	,name AS tablename
 	,rows AS rowcount_on_slice
-	,SUM(rows) OVER (PARTITION BY name) AS total_rowcount
+	,SUM(rows) OVER (PARTITION BY name, id) AS total_rowcount
 	,CASE
 		WHEN rows IS NULL OR rows = 0 THEN 0
 		ELSE ROUND(CAST(rows AS FLOAT) / CAST((SUM(rows) OVER (PARTITION BY id)) AS FLOAT) * 100, 3) 


### PR DESCRIPTION
Window function with PARTITION BY name will cause total_rowcount to be the sum of rows across tables which share a name. If there are multiple tables with the same name existing in different schema this would be a problem.