### PR TITLE
Ensure float division for RETRY_TIMEOUT

### DIFF
--- a/src/ColumnEncodingUtility/analyze-schema-compression.py
+++ b/src/ColumnEncodingUtility/analyze-schema-compression.py
@@ -54,7 +54,7 @@ TERMINATED_BY_USER = 4
 NO_CONNECTION = 5
 
 # timeout for retries - 100ms
-RETRY_TIMEOUT = 100 / 1000
+RETRY_TIMEOUT = 100. / 1000
     
 master_conn = None
 db_connections = {}


### PR DESCRIPTION
`100 / 1000` yields `0` in Python 2, which is not what's wanted here.