### PR TITLE
filter_used fixed count and sum

### DIFF
--- a/src/AdminScripts/filter_used.sql
+++ b/src/AdminScripts/filter_used.sql
@@ -15,12 +15,12 @@ Use the perm_table_name fileter to narrow the results
 History:
 2015-02-09 ericfe created
 **********************************************************************************************/
-select trim(s.perm_Table_name) as table , substring(trim(info),1,180) as filter, sum(datediff(seconds,starttime,endtime)) as secs, count(*) as num, max(i.query) as query  
-from stl_explain  p
-join stl_plan_info i on ( i.userid=p.userid  and i.query=p.query and i.nodeid=p.nodeid  ) 
-join stl_scan s on (s.userid=i.userid and s.query=i.query and  s.segment=i.segment and  s.step=i.step) 
-where  s.starttime > dateadd(day, -7, current_Date)
-  and   s.perm_table_name not like 'Internal Worktable%'
-  and p.info <> ''
-  and s.perm_table_name like '%' -- chose table(s) to look for
+select trim(s.perm_Table_name) as table , substring(trim(info),1,180) as filter, sum(datediff(seconds,starttime,case when starttime > endtime then starttime else endtime end)) as secs, count(distinct i.query) as num, max(i.query) as query
+from stl_explain p
+join stl_plan_info i on ( i.userid=p.userid and i.query=p.query and i.nodeid=p.nodeid )
+join stl_scan s on (s.userid=i.userid and s.query=i.query and s.segment=i.segment and s.step=i.step)
+where s.starttime > dateadd(day, -7, current_Date)
+and s.perm_table_name not like 'Internal Worktable%'
+and p.info <> ''
+and s.perm_table_name like '%' -- choose table(s) to look for
 group by 1,2 order by 1, 4 desc , 3 desc;

--- a/src/AdminScripts/filter_used.sql
+++ b/src/AdminScripts/filter_used.sql
@@ -15,6 +15,7 @@ Use the perm_table_name fileter to narrow the results
 History:
 2015-02-09 ericfe created
 **********************************************************************************************/
+
 select trim(s.perm_Table_name) as table , substring(trim(info),1,180) as filter, sum(datediff(seconds,starttime,case when starttime > endtime then starttime else endtime end)) as secs, count(distinct i.query) as num, max(i.query) as query
 from stl_explain p
 join stl_plan_info i on ( i.userid=p.userid and i.query=p.query and i.nodeid=p.nodeid )


### PR DESCRIPTION
Scans being processed during cancelled queries would have an incorrect endtime that would ruin the sum aggregate. 

Count(*) function was counting per slice. These have both been corrected.