### PR TITLE
Add quotes around table name in table privilege admin view.

### DIFF
--- a/src/AdminViews/v_get_tbl_priv_by_user.sql
+++ b/src/AdminViews/v_get_tbl_priv_by_user.sql
@@ -19,7 +19,7 @@ FROM
 		,HAS_TABLE_PRIVILEGE(usrs.usename, obj, 'delete') AS del
 		,HAS_TABLE_PRIVILEGE(usrs.usename, obj, 'references') AS ref
 	FROM
-		(SELECT schemaname, tablename, schemaname + '.' + tablename AS obj FROM pg_tables) AS objs
+		(SELECT schemaname, tablename, '\"' + schemaname + '\"' + '.' + '\"' + tablename + '\"' AS obj FROM pg_tables) AS objs
 		,(SELECT * FROM pg_user) AS usrs
 	ORDER BY obj
 	)


### PR DESCRIPTION
In the current version, table names with a space create the error:
```
ERROR:  invalid name syntax
```