### PR TITLE
Use a delimited identifier for column names.

### DIFF
--- a/src/ColumnEncodingUtility/analyze-schema-compression.py
+++ b/src/ColumnEncodingUtility/analyze-schema-compression.py
@@ -454,7 +454,7 @@ def analyze(tables):
                 non_identity_columns.append(col)
 
             # add the formatted column specification
-            encode_columns.extend(['%s %s %s %s encode %s %s'
+            encode_columns.extend(['"%s" %s %s %s encode %s %s'
                                    % (col, col_type, default_value, col_null, compression, distkey)])
 
         fks = None 


### PR DESCRIPTION
When constructing the create statement, the script will fail if any
column names that would be otherwise taken as a key word.  This commit
puts double quotes around each column name to prevent that.