### PR TITLE
a couple of small changes to make analyze-vacuum-schema a little bit easier to integrate with a third-party python project

### DIFF
--- a/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
+++ b/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
@@ -50,7 +50,7 @@ import traceback
 import datetime
 from string import uppercase
 
-__version__ = ".9.1.3.3"
+__version__ = ".9.1.3.4"
 
 ERROR = 1
 INVALID_ARGS = 2

--- a/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
+++ b/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
@@ -52,7 +52,6 @@ from string import uppercase
 
 __version__ = ".9.1.3.3"
 
-OK = 0
 ERROR = 1
 INVALID_ARGS = 2
 NO_WORK = 3
@@ -714,7 +713,6 @@ def main(argv):
        
     comment('Processing Complete')
     cleanup()    
-    sys.exit(OK)
 
 if __name__ == "__main__":
     main(sys.argv)

--- a/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
+++ b/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
@@ -559,7 +559,7 @@ def main(argv):
     
     # extract the command line arguments
     try:
-        optlist, remaining = getopt.getopt(sys.argv[1:], "", supported_args.split())
+        optlist, remaining = getopt.getopt(argv[1:], "", supported_args.split())
     except getopt.GetoptError as err:
         print str(err)
         usage(None)


### PR DESCRIPTION
Hi,

I'm trying to use the logic in `analyze-vacuum-schema.py` from python code. I know that the focus was to execute it from command line, but in my case I would like to integrate these housekeeping tasks in my current task framework.

Since the `awslabs/amazon-redshift-utils` project is not organized as a python package, and is not installable with tools like `pip`, is not so trivial to integrate as an external dependency. 

I'm directly importing the `analyze-vacuum-schema.py` from the file path, and thats working ok, but I've found two small changes that make it a little bit easier to use "from outside":

One is to fix what I think is a small bug, because the main method has an `argv` parameter but instead uses `sys.argv`

The second change is not executing sys.exit when the execution completes successfully.

I've created this pull request so you can check those two small changes and see wether it makes sense to merge.

Thanks!