### PR TITLE
Clarified dependency version, Fixes #56

### DIFF
--- a/src/UnloadCopyUtility/README.md
+++ b/src/UnloadCopyUtility/README.md
@@ -61,3 +61,5 @@ sudo easy_install pip
 sudo yum install postgresql postgresql-devel gcc python-devel
 sudo pip install PyGreSQL
 ```
+
+On other Linux distributions, make sure that you install the PostgreSQL client version 9.0 or higher.


### PR DESCRIPTION
The Unload/Copy Utility requires PostgreSQL client 9.0 or higher, triaged in Issue #56. This patch specifies the dependency version in `README`.