### PR TITLE
Add IF NOT EXISTS to the create statement for idempotence

### DIFF
--- a/src/AdminViews/v_generate_tbl_ddl.sql
+++ b/src/AdminViews/v_generate_tbl_ddl.sql
@@ -37,7 +37,7 @@ FROM
    n.nspname AS schemaname
    ,c.relname AS tablename
    ,2 AS seq
-   ,'CREATE TABLE "' + n.nspname + '"."' + c.relname + '"' AS ddl
+   ,'CREATE TABLE IF NOT EXISTS "' + n.nspname + '"."' + c.relname + '"' AS ddl
   FROM pg_namespace AS n
   INNER JOIN pg_class AS c ON n.oid = c.relnamespace
   WHERE c.relkind = 'r'


### PR DESCRIPTION
Hi, 

I would like to propose adding IF NOT EXISTS to this amazing utility so that if can be used in an idempotent manner. One of the use cases I encountered for this script was to archive tables in s3, store their DDL and then drop them from redshift. by having IF NOT EXISTS it makes it easier to create table before restoring them back without worrying about error from table already existing.
