### PR TITLE
pg_internal fixes

### DIFF
--- a/src/AdminScripts/missing_table_stats.sql
+++ b/src/AdminScripts/missing_table_stats.sql
@@ -3,5 +3,6 @@ SELECT substring(trim(plannode),1,100) AS plannode
        ,COUNT(*)
 FROM stl_explain
 WHERE plannode LIKE '%missing statistics%'
+AND plannode NOT LIKE '%redshift_auto_health_check_%'
 GROUP BY plannode
 ORDER BY 2 DESC;

--- a/src/AdminScripts/table_info.sql
+++ b/src/AdminScripts/table_info.sql
@@ -41,7 +41,8 @@ from svv_diskusage group by tbl, name, slice )
 group by tbl, name ) as dist_ratio on a.id = dist_ratio.tbl
 join ( select sum(capacity) as  total
   from stv_partitions where part_begin=0 ) as part on 1=1
-where mbytes is not null 
+where mbytes is not null
+and pgc.relowner > 1 
 -- and pgn.nspname = 'schema' -- schemaname
 -- and a.name like 'table%' -- tablename
 -- and det.max_enc = 0 -- non-compressed tables

--- a/src/AdminScripts/table_inspector.sql
+++ b/src/AdminScripts/table_inspector.sql
@@ -25,7 +25,7 @@ SELECT n.nspname, c.relname, c.oid,
       (SELECT COUNT(*) FROM STV_BLOCKLIST b WHERE b.tbl = c.oid)
 FROM pg_namespace n, pg_class c
 WHERE n.oid = c.relnamespace 
-  AND nspname NOT IN ('pg_catalog', 'pg_toast', 'information_schema')
+  AND nspname NOT IN ('pg_catalog', 'pg_toast', 'information_schema','pg_internal')
   AND c.relname <> 'temp_staging_tables_1';
 
 CREATE TEMP TABLE temp_staging_tables_2

--- a/src/AdminScripts/unscanned_table_summary.sql
+++ b/src/AdminScripts/unscanned_table_summary.sql
@@ -51,7 +51,8 @@ WITH
                 s.userid > 1
                 AND s.perm_table_name NOT IN ('Internal Worktable','S3')
             GROUP BY 
-                tbl, perm_table_name) s ON s.tbl = t.table_id),
+                tbl, perm_table_name) s ON s.tbl = t.table_id
+	WHERE t."schema" NOT IN ('pg_internal')),
     scan_aggs AS (
         SELECT 
             sum(size) AS total_table_size,


### PR DESCRIPTION
With the introduction of pg_internal there are some of our scripts which detail a system table used for health check purposes. Since the end user is unable to access this table we are modifying the scripts to reduce its visibility. 