### PR TITLE
Account for dots in view names

### DIFF
--- a/src/AdminViews/v_get_view_priv_by_user.sql
+++ b/src/AdminViews/v_get_view_priv_by_user.sql
@@ -19,7 +19,7 @@ FROM
 		,HAS_TABLE_PRIVILEGE(usrs.usename, obj, 'delete') AS del
 		,HAS_TABLE_PRIVILEGE(usrs.usename, obj, 'references') AS ref
 	FROM
-		(SELECT schemaname, viewname, schemaname + '.' + viewname AS obj FROM pg_views) AS objs
+		(SELECT schemaname, viewname, ('"' + schemaname + '"."' + viewname + '"') AS obj FROM pg_views ) AS objs
 	INNER JOIN
 		(SELECT * FROM pg_user) AS usrs
 			ON 1 = 1


### PR DESCRIPTION
Our product Pipeline creates view names that sometimes have dots in them depending on how data is passed to our API. Redshift allows this, but this query breaks with the error below if `.` is not taken into account. 

```
ERROR:  cross-database references are not implemented: "schemaname.view.name"
Query failed
PostgreSQL said: cross-database references are not implemented: "schemaname.view.name"
```