### PR TITLE
Only process tables with nice names

### DIFF
--- a/src/ColumnEncodingUtility/analyze-schema-compression.py
+++ b/src/ColumnEncodingUtility/analyze-schema-compression.py
@@ -525,8 +525,8 @@ def analyze(table_info):
                 encode_columns.extend(['"%s" %s %s %s encode %s %s'
                                        % (col, col_type, default_value, col_null, compression, distkey)])
             
-            # if this table's encodings have not changed, then dont do a modification, including if the force options is set
-            if not encodings_modified:
+            # if this table's encodings have not changed, then dont do a modification, unless force options is set
+            if (not force) and (not encodings_modified):
                 comment("Column Encoding resulted in an identical table - no changes will be made")
             else:
                 comment("Column Encoding will be modified for %s.%s" % (analyze_schema, table_name))

--- a/src/ColumnEncodingUtility/analyze-schema-compression.py
+++ b/src/ColumnEncodingUtility/analyze-schema-compression.py
@@ -767,8 +767,7 @@ join pg_namespace as pgn on pgn.oid = pgc.relnamespace
 join (select tbl, count(*) as mbytes
 from stv_blocklist group by tbl) b on a.id=b.tbl
 where pgn.nspname = '%s'
-  and substring(a.name,length(a.name)-3,length(a.name)) != '$old'
-  and substring(a.name,length(a.name)-3,length(a.name)) != '$mig'
+  and a.name::text SIMILAR TO '[A-Za-z_][A-Za-z0-9_]*'
 order by 2;
         ''' % (analyze_schema,)
     


### PR DESCRIPTION
This script fails in many place when tables have names that require quoting, for example:

my_schema."my-stupid-table-name"

Rather than try to quote everywhere, this pull request simply skips those tables.

This was discussed in an earlier issue https://github.com/awslabs/amazon-redshift-utils/issues/54 but it seems nobody is keeping up with comprehensively quoting names. Skipping seems like the simplest solution.