### PR TITLE
Correct DISTKEY check from 'T' to 'TRUE'

### DIFF
--- a/src/ColumnEncodingUtility/analyze-schema-compression.py
+++ b/src/ColumnEncodingUtility/analyze-schema-compression.py
@@ -479,7 +479,7 @@ def analyze(table_info):
                 
                 # is this the dist key?
                 distkey = descr[col][3]
-                if str(distkey).upper() == 'T':
+                if str(distkey).upper() == 'TRUE':
                     distkey = 'DISTKEY'
                 else:
                     distkey = ''


### PR DESCRIPTION
Tested this out locally. This fixes an issue of missing distkeys in the CREATE TABLE statements.