### PR TITLE
Added missing table alias

### DIFF
--- a/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
+++ b/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
@@ -325,7 +325,7 @@ def run_vacuum(conn):
                                                    + ',  Unsorted_pct : ' + COALESCE(CAST(info_tbl."unsorted" AS VARCHAR(10)), 'N/A')
                                                    + ',  Deleted_pct : ' + CAST("empty" AS VARCHAR(10)) +' */ ;'
 
-                                        FROM svv_table_info
+                                        FROM svv_table_info info_tbl
                                         WHERE "schema" = '%s'
                                                 AND   
                                                  (


### PR DESCRIPTION
When running the analyze vacuum Python script, we get the following error:
```
src/AnalyzeVacuumUtility/analyze-vacuum-schema.py --db fatty --db-user joey --db-pwd ******** --db-host dw-test.csl1vvtytte4.us-east-1.redshift.amazonaws.com --db-port 5439 --schema-name public --output-file /var/lib/jenkins/workspace/Run_Analyze_Vacuum_Full/vacuum_full.log --debug True --ignore-errors False --slot-count 5 --vacuum-flag True --vacuum-parameter FULL --analyze-flag True --min-unsorted-pct 5 --max-unsorted-pct 50 --deleted-pct 15 --stats-off-pct 10 --max-table-size-mb 2724178
-- 2016-08-15 02:29:44.400984 [5519] Connect [5519] dw-test.csl1vvtytte4.us-east-1.redshift.amazonaws.com:5439:fatty:joey
-- 2016-08-15 02:29:44.425236 [5519] set search_path = '$user',public
-- 2016-08-15 02:29:44.426728 [5519] set wlm_query_slot_count = 5
-- 2016-08-15 02:29:44.427831 [5519] set statement_timeout = '36000000'
-- 2016-08-15 02:29:44.429020 [5519] Connected to dw-test.csl1vvtytte4.us-east-1.redshift.amazonaws.com:5439:fatty as joey
-- 2016-08-15 02:29:44.429081 [5519] Extracting Candidate Tables for vacuum based on the alerts...
/* [5519]

                SELECT DISTINCT 'vacuum FULL ' + feedback_tbl.schema_name + '.' + feedback_tbl.table_name + ' ; '
                + '/* '+ ' Table Name : ' + info_tbl."schema" + '.' + info_tbl."table" 
                                                   + ',  Size : ' + CAST(info_tbl."size" AS VARCHAR(10)) + ' MB'
                                                   + ',  Unsorted_pct : ' + COALESCE(CAST(info_tbl."unsorted" AS VARCHAR(10)), 'N/A')
                                                   + ',  Deleted_pct : ' + CAST(info_tbl."empty" AS VARCHAR(10)) +' */ ;'
                    FROM (SELECT schema_name,
                                 table_name
                          FROM (SELECT TRIM(n.nspname) schema_name,
                                       c.relname table_name,
                                       DENSE_RANK() OVER (ORDER BY COUNT(*) DESC) AS qry_rnk,
                                       COUNT(*)
                                FROM stl_alert_event_log AS l
                                  JOIN (SELECT query,
                                               tbl,
                                               perm_table_name
                                        FROM stl_scan
                                        WHERE perm_table_name <> 'Internal Worktable'
                                        GROUP BY query,
                                                 tbl,
                                                 perm_table_name) AS s ON s.query = l.query
                                  JOIN pg_class c ON c.oid = s.tbl
                                  JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
                                WHERE l.userid > 1
                                AND   l.event_time >= dateadd (DAY,-1,CURRENT_DATE)
                                AND   l.Solution LIKE '%VACUUM command%'
                                GROUP BY TRIM(n.nspname),
                                         c.relname) anlyz_tbl
                          WHERE anlyz_tbl.qry_rnk < 25) feedback_tbl
                      JOIN svv_table_info info_tbl
                        ON info_tbl.schema = feedback_tbl.schema_name
                       AND info_tbl.table = feedback_tbl.table_name
                    WHERE /*(info_tbl.unsorted > 5 OR info_tbl.empty > 15) AND */  
                        info_tbl.size < 2724178
                        AND   TRIM(info_tbl.schema) = ‘public'
                        AND   (sortkey1 not ilike  'INTERLEAVED%' OR sortkey1 IS NULL)
                    ORDER BY info_tbl.size ASC, info_tbl.skew_rows ASC;
                            
*/

-- 2016-08-15 02:29:50.657286 [5519] Query Execution returned 0 Results
-- 2016-08-15 02:29:50.657429 [5519] Extracting Candidate Tables for vacuum ...
/* [5519]
SELECT DISTINCT 'vacuum FULL ' + "schema" + '.' + "table" + ' ; '
                                                   + '/* '+ ' Table Name : ' + "schema" + '.' + "table" 
                                                   + ',  Size : ' + CAST("size" AS VARCHAR(10)) + ' MB'
                                                   + ',  Unsorted_pct : ' + COALESCE(CAST(info_tbl."unsorted" AS VARCHAR(10)), 'N/A')
                                                   + ',  Deleted_pct : ' + CAST("empty" AS VARCHAR(10)) +' */ ;'

                                        FROM svv_table_info
                                        WHERE "schema" = ‘public'
                                                AND   
                                                 (
                                                --If the size of the table is less than the max_table_size_mb then , run vacuum based on condition: >min_unsorted_pct AND >deleted_pct
                                                    ((size < 2724178) AND (unsorted > 5 OR empty > 15)) 
                                                    OR
                                                --If the size of the table is greater than the max_table_size_mb then , run vacuum based on condition:  
                                                -- >min_unsorted_pct AND < max_unsorted_pct AND >deleted_pct
                                                --This is to avoid big table with large unsorted_pct
                                                     ((size > 2724178) AND (unsorted > 5 AND unsorted < 50 ))
                                                 )
                                                AND (sortkey1 not ilike  'INTERLEAVED%' OR sortkey1 IS NULL)
                                        ORDER BY "size" ASC ,skew_rows ASC;

                                        
*/

Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/Run_Analyze_Vacuum_Full/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py", line 720, in <module>
    main(sys.argv)
  File "/var/lib/jenkins/workspace/Run_Analyze_Vacuum_Full/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py", line 706, in main
    run_vacuum(master_conn)
  File "/var/lib/jenkins/workspace/Run_Analyze_Vacuum_Full/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py", line 349, in run_vacuum
    vacuum_statements = execute_query(get_vacuum_statement)
  File "/var/lib/jenkins/workspace/Run_Analyze_Vacuum_Full/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py", line 97, in execute_query
    query_result = conn.query(str)
pg.ProgrammingError: ERROR:  relation "info_tbl" does not exist

Build step 'Execute shell' marked build as failure
Finished: FAILURE
```

It looks like the statement `info_tbl."unsorted"` (in the comment section) is incorrect as the table `info_tbl` is not defined, i.e. the table alias `info_tbl` is missing from the FROM statement for the table `svv_table_info` on the second phase.

We could also replace the statement `info_tbl."unsorted"` with `svv_table_info."unsorted"`, but we opted for the alias approach instead, in order to be consistent with how the other SQL statements are created in the script.
