### PR TITLE
Criteria for opening the brackets and closing them must be the same

### DIFF
--- a/src/AdminViews/v_generate_tbl_ddl.sql
+++ b/src/AdminViews/v_generate_tbl_ddl.sql
@@ -194,7 +194,7 @@ from (SELECT
   INNER JOIN  pg_class AS c ON n.oid = c.relnamespace
   INNER JOIN  pg_attribute AS a ON c.oid = a.attrelid
   WHERE c.relkind = 'r'
-    AND a.attsortkeyord > 0
+    AND abs(a.attsortkeyord) > 0
     AND a.attnum > 0
   --END SEMICOLON
   UNION SELECT n.nspname AS schemaname, c.relname AS tablename, 600000000 AS seq, ';' AS ddl


### PR DESCRIPTION
I had an issue with table DDL not closing the bracket for interleaved sort keys. This is easily fixed by matching WHERE criteria for opening brackets with the one used for closing brackets.