### PR TITLE
Create the kmsClient earlier so access key credentials can be decrypted

### DIFF
--- a/src/UnloadCopyUtility/redshift-unload-copy.py
+++ b/src/UnloadCopyUtility/redshift-unload-copy.py
@@ -147,6 +147,9 @@ def main(args):
     global s3Client    
     s3Client = boto.s3.connect_to_region(region)
     
+    global kmsClient
+    kmsClient = boto.kms.connect_to_region(region)
+    
     # load the configuration
     getConfig(args[1])
     
@@ -196,9 +199,6 @@ def main(args):
     dest_schema = destConfig['schemaName']
     dest_table = destConfig['tableName']
     dest_user = destConfig['connectUser']
-    
-    global kmsClient
-    kmsClient = boto.kms.connect_to_region(region)
     
     # create a new data key for the unload operation        
     dataKey = kmsClient.generate_data_key(encryptionKeyID, key_spec="AES_256")


### PR DESCRIPTION
Merging #111 added decryption of access keys before we had created the kmsClient. This makes kmsClient creation happen earlier.