### PR TITLE
Adding new view v_get_compressed_sortkey_columns

### DIFF
--- a/src/AdminViews/README.md
+++ b/src/AdminViews/README.md
@@ -21,6 +21,7 @@ All views assume you have a schema called admin.
 | v_generate_user_object_permissions.sql |   View to get the DDL for a users permissions to tables and views. | 
 | v_generate_view_ddl.sql |   View to get the DDL for a view. | 
 | v_get_cluster_restart_ts.sql | View to get the datetime of when Redshift cluster was recently restarted |
+| v_get_compressed_sortkey_columns.sql | View to get a list of columns that have the SORTKEY compressed |
 | v_get_obj_priv_by_user.sql |   View to get the table/views that a user has access to | 
 | v_get_schema_priv_by_user.sql |   View to get the schema that a user has access to | 
 | v_get_tbl_priv_by_user.sql |   View to get the tables that a user has access to | 

--- a/src/AdminViews/v_get_compressed_sortkey_columns.sql
+++ b/src/AdminViews/v_get_compressed_sortkey_columns.sql
@@ -1,0 +1,34 @@
+--DROP VIEW admin.v_get_compressed_sortkey_columns;
+/**********************************************************************************************
+Purpose: View to get a list of columns that have the SORTKEY compressed.
+
+         Only the first column of the sort key is checked.
+         If there is more than 1 column in the sort it is ok if columns >= 2 are compressed.
+                 (AND a.attsortkeyord = 1)
+
+         The reason it is not desirable to have the first column of a SORTKEY compressed
+         is because it can cause the following alert event.
+
+                Very selective query filter
+
+         The AdminScript named perf_alert.sql can show queries that have this alert event.
+
+History:
+2016-10-21 michaelcunningham Created
+**********************************************************************************************/
+CREATE OR REPLACE VIEW admin.v_get_compressed_sortkey_columns
+AS
+SELECT  n.nspname AS schemaname, c.relname AS tablename, a.attname AS colname,
+        CASE  WHEN format_encoding((a.attencodingtype)::integer) = 'none' THEN ''
+              ELSE 'encode ' + format_encoding((a.attencodingtype)::integer)
+              END AS colencoding
+FROM    pg_namespace AS n
+        INNER JOIN pg_class AS c
+            ON n.oid = c.relnamespace
+        INNER JOIN pg_attribute AS a
+            ON c.oid = a.attrelid
+WHERE   c.relkind = 'r'
+AND     a.attnum > 0
+AND     a.attsortkeyord = 1
+AND     a.attencodingtype > 0
+ORDER BY n.nspname, c.relname, a.attnum;


### PR DESCRIPTION
Can help with finding sortkey columns that are compressed.
The first column of a sortkey should not be compressed because it can
cause Very selective query filter alert event.
