### PR TITLE
Use oid rather than relfilenode for catalog joins

### DIFF
--- a/src/AdminViews/v_generate_tbl_ddl.sql
+++ b/src/AdminViews/v_generate_tbl_ddl.sql
@@ -88,7 +88,7 @@ FROM
    ,200000000 + CAST(con.oid AS INT) AS seq
    ,'\t,' + pg_get_constraintdef(con.oid) AS ddl
   FROM pg_constraint AS con
-  INNER JOIN pg_class AS c ON c.relnamespace = con.connamespace AND c.relfilenode = con.conrelid
+  INNER JOIN pg_class AS c ON c.relnamespace = con.connamespace AND c.oid = con.conrelid
   INNER JOIN pg_namespace AS n ON n.oid = c.relnamespace
   WHERE c.relkind = 'r' AND pg_get_constraintdef(con.oid) NOT LIKE 'FOREIGN KEY%'
   ORDER BY seq)
@@ -209,7 +209,7 @@ from (SELECT
     FROM pg_constraint AS con
       INNER JOIN pg_class AS c
               ON c.relnamespace = con.connamespace
-             AND c.relfilenode = con.conrelid
+             AND c.oid = con.conrelid
       INNER JOIN pg_namespace AS n ON n.oid = c.relnamespace
     WHERE c.relkind = 'r'
     AND   pg_get_constraintdef (con.oid) LIKE 'FOREIGN KEY%'


### PR DESCRIPTION
Checking Redshift documentation [here](http://docs.aws.amazon.com/redshift/latest/dg/c_join_PG.html)
which links to PostgreSQL documentation [here](https://www.postgresql.org/docs/8.0/static/catalog-pg-constraint.html)
The `conrelid` column in the `pg_constraint` table references the `oid`
of `pg_class`, so using `oid` rather than unreliable `relfilenode`

Was able to recreate and fix #119
