### PR TITLE
Remove escaped quotes in comment

### DIFF
--- a/src/AdminViews/v_generate_tbl_ddl.sql
+++ b/src/AdminViews/v_generate_tbl_ddl.sql
@@ -119,7 +119,7 @@ FROM pg_namespace AS n
   n.nspname AS schemaname
    ,c.relname AS tablename
    ,1 AS seq  
-   ,'--WARNING: This DDL inherited the \'BACKUP NO\' property from the source table' as ddl
+   ,'--WARNING: This DDL inherited the BACKUP NO property from the source table' as ddl
 FROM pg_namespace AS n
   INNER JOIN pg_class AS c ON n.oid = c.relnamespace
   INNER JOIN (SELECT 


### PR DESCRIPTION
When attempting to run this in DataGrip, this script wouldn't run. It seemed to complain about the UNION statments, but it turned out to be an issue with the quote escaping in the comment for `BACKUP NO`, so I've removed them