### PR TITLE
Create view to get reads and writes per table with query and transaction ID.

### DIFF
--- a/src/AdminViews/README.md
+++ b/src/AdminViews/README.md
@@ -24,6 +24,7 @@ All views assume you have a schema called admin.
 | v_get_obj_priv_by_user.sql |   View to get the table/views that a user has access to | 
 | v_get_schema_priv_by_user.sql |   View to get the schema that a user has access to | 
 | v_get_tbl_priv_by_user.sql |   View to get the tables that a user has access to | 
+| v_get_tbl_reads_and_writes.sql | View to get operations performed per table for transactions ID or query ID |
 | v_get_tbl_scan_frequency.sql |   View to get list of each permanent table's scan frequency | 
 | v_get_users_in_group.sql |   View to get all users in a group | 
 | v_get_vacuum_details.sql | View to get vacuum details like table name, Schema Name, Deleted Rows , processing time |

--- a/src/AdminViews/v_get_tbl_reads_and_writes.sql
+++ b/src/AdminViews/v_get_tbl_reads_and_writes.sql
@@ -1,7 +1,7 @@
 --DROP VIEW admin.v_get_tbl_reads_and_writes;
 /**********************************************************************************************
 Purpose: View to get the READ and WRITE operations per table.  This view should be used with a
-filter that limits the output for query IDs and transaction IDs.  This view will help to see 
+filter that limits the output for query IDs and/or transaction IDs.  This view will help to see 
 what tables are operated on by transactions or queries.
 History:
 2016-11-03 pvbouwel Created
@@ -9,11 +9,11 @@ History:
 CREATE OR REPLACE VIEW admin.v_get_tbl_reads_and_writes
 AS
 WITH v_operations AS 
-  ( SELECT query, tbl, min(starttime) AS starttime, max(endtime) AS endtime,'R' AS operation FROM stl_scan GROUP BY query, tbl
+  ( SELECT query, tbl, min(starttime) AS starttime, max(endtime) AS endtime, 'R' AS operation FROM stl_scan GROUP BY query, tbl
       UNION ALL
-    SELECT query,tbl,min(starttime) AS starttime,max(endtime) AS endtime,'w' AS operation FROM stl_delete GROUP BY query,tbl
+    SELECT query, tbl, min(starttime) AS starttime, max(endtime) AS endtime, 'w' AS operation FROM stl_delete GROUP BY query, tbl
       UNION ALL
-    SELECT query,tbl,min(starttime) AS starttime,max(endtime) AS endtime,'W' AS operation FROM stl_insert GROUP BY query,tbl
+    SELECT query, tbl, min(starttime) AS starttime, max(endtime) AS endtime, 'W' AS operation FROM stl_insert GROUP BY query, tbl
   )
 SELECT
   sq.xid

--- a/src/AdminViews/v_get_tbl_reads_and_writes.sql
+++ b/src/AdminViews/v_get_tbl_reads_and_writes.sql
@@ -1,8 +1,9 @@
 --DROP VIEW admin.v_get_tbl_reads_and_writes;
 /**********************************************************************************************
-Purpose: View to get the READ and WRITE operations per table.  This view should be used with a
-filter that limits the output for query IDs and/or transaction IDs.  This view will help to see 
-what tables are operated on by transactions or queries.  The operation will be one of the 
+Purpose: View to get the READ and WRITE operations per table for specific transactions.  
+This view should be used with a filter that limits the output for transaction IDs or query IDs.  
+This view will help to see what tables are operated on by transactions and to see how transactions
+have dependencies between each other.  The operation will be one of the 
 following:
  - R if it is a read operation that was done
  - W if it is a write operation that was done
@@ -20,12 +21,12 @@ CREATE OR REPLACE VIEW admin.v_get_tbl_reads_and_writes
 AS
 WITH v_operations AS 
   ( SELECT query, tbl, 'R' AS operation FROM stl_scan WHERE type=2 GROUP BY query, tbl
-      UNION ALL
+      UNION
     SELECT query, tbl, 'W' AS operation FROM stl_delete GROUP BY query, tbl
-      UNION ALL
+      UNION
     SELECT query, tbl, 'W' AS operation FROM stl_insert GROUP BY query, tbl
-      UNION ALL
-    SELECT query, NULL::int as tbl, 'A' AS operation FROM stl_query WHERE aborted=1 GROUP BY query, tbl
+      UNION
+    SELECT sq.query AS query, stc.table_id AS tbl, 'A' AS operation FROM stl_query sq LEFT JOIN stl_tr_conflict stc on sq.xid = stc.xact_id  where aborted=1 GROUP BY query, tbl
   ),
 v_end_of_transaction AS
   ( SELECT xid, MAX(tx_action) AS tx_action, MAX(endtime) as endtime FROM
@@ -37,14 +38,36 @@ v_end_of_transaction AS
     ) GROUP BY xid
   )
 SELECT
-  sq.xid as xid
-  ,sq.query as query
-  ,vo.tbl as tbl
-  ,vo.operation as operation
-  ,sq.starttime as statement_starttime
-  ,sq.endtime as statement_endtime
-  ,ve.endtime as transaction_endtime
-  ,ve.tx_action as transaction_action
-FROM stl_query sq
-     LEFT JOIN v_operations vo ON sq.query=vo.query
-     LEFT JOIN v_end_of_transaction ve ON sq.xid=ve.xid;
+  xid
+  ,query
+  ,tbl
+  ,operation
+  ,statement_starttime
+  ,statement_endtime
+  ,transaction_endtime
+  ,transaction_action
+FROM (
+  SELECT
+    sq.xid as xid
+    ,sq.query as query
+    ,vo.tbl as tbl
+    ,vo.operation as operation
+    ,sq.starttime as statement_starttime
+    ,sq.endtime as statement_endtime
+    ,ve.endtime as transaction_endtime
+    ,ve.tx_action as transaction_action
+  FROM stl_query sq
+       LEFT JOIN v_operations vo ON sq.query=vo.query
+       LEFT JOIN v_end_of_transaction ve ON sq.xid=ve.xid
+  UNION ALL
+    SELECT
+     xid as xid
+     ,null as query
+     ,null as tbl
+     ,'C' as operation
+     ,startqueue as statement_starttime
+     ,endtime as statement_endtime
+     ,endtime as transaction_endtime
+     ,'C' as transaction_action
+    FROM stl_commit_stats where node=-1
+) order by statement_starttime;

--- a/src/AdminViews/v_get_tbl_reads_and_writes.sql
+++ b/src/AdminViews/v_get_tbl_reads_and_writes.sql
@@ -1,0 +1,26 @@
+--DROP VIEW admin.v_get_tbl_reads_and_writes;
+/**********************************************************************************************
+Purpose: View to get the READ and WRITE operations per table.  This view should be used with a
+filter that limits the output for query IDs and transaction IDs.  This view will help to see 
+what tables are operated on by transactions or queries.
+History:
+2016-11-03 pvbouwel Created
+**********************************************************************************************/
+CREATE OR REPLACE VIEW admin.v_get_tbl_reads_and_writes
+AS
+WITH v_operations AS 
+  ( SELECT query, tbl, min(starttime) AS starttime, max(endtime) AS endtime,'R' AS operation FROM stl_scan GROUP BY query, tbl
+      UNION ALL
+    SELECT query,tbl,min(starttime) AS starttime,max(endtime) AS endtime,'w' AS operation FROM stl_delete GROUP BY query,tbl
+      UNION ALL
+    SELECT query,tbl,min(starttime) AS starttime,max(endtime) AS endtime,'W' AS operation FROM stl_insert GROUP BY query,tbl
+  )
+SELECT
+  sq.xid
+  ,sq.query
+  ,vo.tbl
+  ,vo.operation
+  ,vo.starttime
+  ,vo.endtime
+FROM stl_query sq
+     LEFT JOIN v_operations vo ON sq.query=vo.query;

--- a/src/AdminViews/v_get_tbl_reads_and_writes.sql
+++ b/src/AdminViews/v_get_tbl_reads_and_writes.sql
@@ -2,25 +2,33 @@
 /**********************************************************************************************
 Purpose: View to get the READ and WRITE operations per table.  This view should be used with a
 filter that limits the output for query IDs and/or transaction IDs.  This view will help to see 
-what tables are operated on by transactions or queries.
+what tables are operated on by transactions or queries.  The operation will be one of the 
+following:
+ - R if it is a read operation that was done
+ - W if it is a write operation that was done
+ - A if the query statement got aborted this could be due to a serializable isolation violation
+   the user will need to check the query manually.
+
 History:
 2016-11-03 pvbouwel Created
 **********************************************************************************************/
 CREATE OR REPLACE VIEW admin.v_get_tbl_reads_and_writes
 AS
 WITH v_operations AS 
-  ( SELECT query, tbl, min(starttime) AS starttime, max(endtime) AS endtime, 'R' AS operation FROM stl_scan GROUP BY query, tbl
+  ( SELECT query, tbl, 'R' AS operation FROM stl_scan WHERE type=2 GROUP BY query, tbl
       UNION ALL
-    SELECT query, tbl, min(starttime) AS starttime, max(endtime) AS endtime, 'w' AS operation FROM stl_delete GROUP BY query, tbl
+    SELECT query, tbl, 'W' AS operation FROM stl_delete GROUP BY query, tbl
       UNION ALL
-    SELECT query, tbl, min(starttime) AS starttime, max(endtime) AS endtime, 'W' AS operation FROM stl_insert GROUP BY query, tbl
+    SELECT query, tbl, 'W' AS operation FROM stl_insert GROUP BY query, tbl
+      UNION ALL
+    SELECT query, NULL::int as tbl, 'A' AS operation FROM stl_query WHERE aborted=1 GROUP BY query, tbl
   )
 SELECT
   sq.xid
   ,sq.query
   ,vo.tbl
   ,vo.operation
-  ,vo.starttime
-  ,vo.endtime
+  ,sq.starttime
+  ,sq.endtime
 FROM stl_query sq
      LEFT JOIN v_operations vo ON sq.query=vo.query;

--- a/src/AdminViews/v_get_tbl_reads_and_writes.sql
+++ b/src/AdminViews/v_get_tbl_reads_and_writes.sql
@@ -9,6 +9,10 @@ following:
  - A if the query statement got aborted this could be due to a serializable isolation violation
    the user will need to check the query manually.
 
+Another output is the transaction actions (tx_action) which will be:
+ - R if the transaction is rolled back
+ - C if the transaction is committed
+
 History:
 2016-11-03 pvbouwel Created
 **********************************************************************************************/
@@ -22,13 +26,25 @@ WITH v_operations AS
     SELECT query, tbl, 'W' AS operation FROM stl_insert GROUP BY query, tbl
       UNION ALL
     SELECT query, NULL::int as tbl, 'A' AS operation FROM stl_query WHERE aborted=1 GROUP BY query, tbl
+  ),
+v_end_of_transaction AS
+  ( SELECT xid, MAX(tx_action) AS tx_action, MAX(endtime) as endtime FROM
+    (  SELECT xid, 'R' AS tx_action, endtime FROM stl_utilitytext WHERE text ILIKE '%rollback%' OR text ILIKE '%aborted%'
+         UNION ALL
+       SELECT xid, 'C' AS tx_action, endtime FROM stl_utilitytext WHERE text ILIKE '%commit%' OR text ILIKE '%end%'
+         UNION ALL
+       SELECT xid, 'C' AS tx_action, endtime from stl_commit_stats WHERE node=-1
+    ) GROUP BY xid
   )
 SELECT
-  sq.xid
-  ,sq.query
-  ,vo.tbl
-  ,vo.operation
-  ,sq.starttime
-  ,sq.endtime
+  sq.xid as xid
+  ,sq.query as query
+  ,vo.tbl as tbl
+  ,vo.operation as operation
+  ,sq.starttime as statement_starttime
+  ,sq.endtime as statement_endtime
+  ,ve.endtime as transaction_endtime
+  ,ve.tx_action as transaction_action
 FROM stl_query sq
-     LEFT JOIN v_operations vo ON sq.query=vo.query;
+     LEFT JOIN v_operations vo ON sq.query=vo.query
+     LEFT JOIN v_end_of_transaction ve ON sq.xid=ve.xid;


### PR DESCRIPTION
The idea behind this view is to easily see how queries and transactions interact with tables.  This view should be used with a filter on queryID or transactionID.  It shows the operation R for Read and W for Write which can help to understand locks that were taken or also dependencies between queries (which can help to understand serializable isolation occurrences).