### PR TITLE
Uses argv passed into main, rather than sys.argv 

### DIFF
--- a/src/ColumnEncodingUtility/analyze-schema-compression.py
+++ b/src/ColumnEncodingUtility/analyze-schema-compression.py
@@ -994,7 +994,7 @@ def main(argv):
     
     # extract the command line arguments
     try:
-        optlist, remaining = getopt.getopt(sys.argv[1:], "", supported_args.split())
+        optlist, remaining = getopt.getopt(argv[1:], "", supported_args.split())
     except getopt.GetoptError as err:
         print str(err)
         usage(None)


### PR DESCRIPTION
So that main can be called with custom args from another python script.