### PR TITLE
Fixes and enhancements to SnapshotManager 

### DIFF
--- a/src/SnapshotManager/README.md
+++ b/src/SnapshotManager/README.md
@@ -29,7 +29,7 @@ That's where this module comes in - by supplying a simple configuration, you can
 
 ### Install Pre-requisites
 
-The included build script requires that you be able to use a terminal/command line, and have the [aws-cli](https://aws.amazon.com/cli), python (2.7x) and [boto3](https://github.com/boto/boto3) installed. Alternatively you can deploy the zip file in the ['dist'](dist/RedshiftSnapshotManager-1.0.0.zip) folder and configure through the AWS Console.
+The included build script requires that you be able to use a terminal/command line, and have the [aws-cli](https://aws.amazon.com/cli), python (2.7x), [boto3](https://github.com/boto/boto3), and [shortuuid](https://pypi.python.org/pypi/shortuuid) installed. Alternatively you can deploy the zip file in the ['dist'](dist/RedshiftSnapshotManager-1.0.0.zip) folder and configure through the AWS Console.
 
 ### Deploy the Lambda Function
 
@@ -56,9 +56,19 @@ where `<role-arn>` is the Amazon Resource Name for the IAM you want the function
             "Resource": [
                 "*"
             ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents"
+            ],
+            "Resource": "arn:aws:logs:*:*:*"
         }
     ]
 }
+
 ```
 
 You only need to deploy the function once to support a virtually unlimited number of clusters. The function will be configured with:
@@ -102,7 +112,7 @@ Running the schedule command will create a CloudWatch Events Schedule that runs 
 
 After completion, you'll notice a Lambda Function called `RedshiftUtilsSnapshotManager`, plus there will be a CloudWatch Events Rule called `RedshiftUtilsSnapshotManager-<namespace>-15-mins` which runs every 15 minutes.
 
-You can run `./build.sh schedule <config.json>` as many times as you need to create additional schedules.
+You can run `./build.sh schedule <config.json>` as many times as you need to create additional schedules or modify existing schedules (based on the namespace supplied in the config file).
 
 ### Confirm Execution
 

--- a/src/SnapshotManager/build.sh
+++ b/src/SnapshotManager/build.sh
@@ -67,7 +67,7 @@ if [ "$action" == "deploy" ]; then
 fi
 
 if [ "$action" == "schedule" -o "$following_action" == "schedule" ]; then
-	python schedule.py $config_file $existing_code_location
+	python schedule.py $config_file
 	
 	# Allow CloudWatch Events to invoke our Lambda Function
 	#aws lambda add-permission --function-name $function_name --statement-id $function_nameCWEventsPermission-`date +"%Y-%m-%dt%H%M%S"` --action 'lambda:InvokeFunction' --principal events.amazonaws.com --source-arn $event_rule_arn

--- a/src/SnapshotManager/schedule.py
+++ b/src/SnapshotManager/schedule.py
@@ -11,8 +11,9 @@ function_name = "RedshiftUtilsSnapshotManager"
 
 def schedule(args):
     config = args[0]
-    function_arn = args[1].replace('"', '')
+    
     cw = boto3.client('events', region_name=os.environ['AWS_REGION'])
+    lb = boto3.client('lambda', region_name=os.environ['AWS_REGION'])
 
     # read the supplied configuration file
     config_file = open(config, 'r')
@@ -21,21 +22,49 @@ def schedule(args):
     
     rulename = "%s-%s-%s-mins" % (function_name, namespace, schedule_mins)
     
+    print "\nChecking whether rule '%s' already exists..." % (rulename)
+    
+    rule_exists = True
+    action = 'Created'
+    
+    try:
+        existing_rule = cw.describe_rule(Name=rulename)
+        action = 'Updated'
+        print "Rule already exists, so updating..."
+    except Exception as e:
+        rule_exists = False
+        print "Rule does not exist, so creating..."
+        
     # create the cloudwatch event rule
     rule = cw.put_rule(Name=rulename,
     ScheduleExpression='rate(%s minutes)' % (schedule_mins),
     State='ENABLED')
     
-    print "Created CloudWatch Rule Definition %s\n" % (rule["RuleArn"])
+    rule_arn = rule["RuleArn"]
     
-    # add the CW target
-    target = {}
-    target["Id"] = "%s" % (namespace)
-    target["Arn"] = function_arn
-    target["Input"] = json.dumps(json_config)
-    target = cw.put_targets(Rule=rulename, Targets=[target])
+    print "%s CloudWatch rule definition: %s" % (action, rule_arn)
     
-    print "Linked Lambda Function %s to Rule\n" % (function_arn)
+    if not rule_exists: 
+    
+        # trust CW to invoke function
+        permission = lb.add_permission(FunctionName=function_name, 
+        StatementId=shortuuid.uuid(), 
+        Action='lambda:InvokeFunction', 
+        Principal='events.amazonaws.com', 
+        SourceArn=rule_arn)
+        
+        print "Updated Lambda policy so that it can be triggered by CloudWatch rule."
+        
+        # add the CW target
+        function_arn = lb.get_function(FunctionName=function_name)["Configuration"]["FunctionArn"]
+        
+        target = {}
+        target["Id"] = "%s" % (namespace)
+        target["Arn"] = function_arn
+        target["Input"] = json.dumps(json_config)
+        target = cw.put_targets(Rule=rulename, Targets=[target])
+           
+        print "Linked Lambda function %s to rule.\n" % (function_arn)
     
 if __name__ == "__main__":
    schedule(sys.argv[1:])    


### PR DESCRIPTION
- Fixed 'build.sh schedule <config.json>' to work as documented. 
- When creating a CloudWatch rule, the script now adds permissions to the Lambda function's policy, allowing the function to be invoked by the  rule. 
- Updated README example role policy, adding permissions to write to CloudWatch logs from Lambda.