### PR TITLE
avoid creating null vacuum statements for tables with interleaved sortkeys

### DIFF
--- a/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
+++ b/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
@@ -364,7 +364,7 @@ def run_vacuum(conn):
         comment("Extracting Candidate Tables for vacuum reindex ...")
         get_vacuum_statement = ''' SELECT DISTINCT 'vacuum REINDEX ' + schema_name + '."' + table_name + '" ; ' + '/* ' + ' Table Name : '
                                     + schema_name + '."' + table_name + '",  Rows : ' + CAST("rows" AS VARCHAR(10))
-                                    + ',  Interleaved_skew : ' + CAST("max_skew" AS VARCHAR(10))
+                                    + ',  Interleaved_skew : ' + COALESCE(CAST("max_skew" AS VARCHAR(10)),'N/A')
                                     + ' ,  Reindex Flag : '  + CAST(reindex_flag AS VARCHAR(10)) + ' */ ;'
 
                                 FROM (SELECT TRIM(n.nspname) schema_name, t.relname table_name,


### PR DESCRIPTION
The current code fails to vacuum any table with null as max_skew and an interleaved sortkey.

Nulls need to be handled in the string construction of the vacuum statement. Specifically, without the COALESCE I add in this PR, all vacuum statements tables with NULL as max_skew would collapse into one null vacuum statement in the SELECT DISTINCT. 

