### PR TITLE
Link finished vacuum details to their start

### DIFF
--- a/src/AdminViews/v_get_vacuum_details.sql
+++ b/src/AdminViews/v_get_vacuum_details.sql
@@ -33,7 +33,6 @@ FROM stl_vacuum vac_start
     ON vac_start.userid = vac_end.userid
    AND vac_start.table_id = vac_end.table_id
    AND vac_start.xid = vac_end.xid
-   AND vac_start.status = 'Started'
    AND vac_end.status = 'Finished'
 
   JOIN (SELECT DISTINCT TRIM(pgn.nspname) AS schema_name,
@@ -42,4 +41,5 @@ FROM stl_vacuum vac_start
         FROM stv_tbl_perm tbl
           JOIN pg_class pgc ON pgc.oid = tbl.id
           JOIN pg_namespace pgn ON pgn.oid = pgc.relnamespace) tab ON tab.table_id = vac_start.table_id
+WHERE vac_start.status != 'Finished'
 ORDER BY rows_deleted DESC;


### PR DESCRIPTION
This patch fixes two issues with `v_get_vacuum_details`:

1. `Finished` details incorrectly showed up as new rows in the data: a
   `start_status` of `Finished` doesn't make much sense.

2. Some `Finished` details were not returned in the `end_*` columns. This
   happened when `start_status` was something other than `Started`, such as when
   Redshift (correctly) decides to do a "Delete Only" operation.

There's no change to `Skipped` output.

Example before:

```
$ redshift.sh -c 'select * from admin.v_get_vacuum_details order by schema_name, table_name, start_time;'
 userid |   xid    | table_id | schema_name |       table_name               |          start_status          | start_rows | start_blocks |         start_time         |           end_status           | end_rows  | end_blocks |          end_time          | rows_deleted | blocks_deleted_added | processing_seconds 
--------+----------+----------+-------------+--------------------------------+--------------------------------+------------+--------------+----------------------------+--------------------------------+-----------+------------+----------------------------+--------------+----------------------+--------------------
    123 | 14109523 |  1330397 | schema1     | skipped_table                  | Skipped                        |          3 |           15 | 2017-06-15 17:56:08.254676 |                                |           |            |                            |              |                      |                   
    123 | 14181682 |  1000856 | schema2     | delete_only_table              | Started Delete Only (To 95%)   | 2352227448 |       895997 | 2017-06-16 23:21:12.407167 |                                |           |            |                            |              |                      |                   
    123 | 14181682 |  1000856 | schema2     | delete_only_table              | Finished                       |  161281455 |        73704 | 2017-06-16 23:36:08.781039 |                                |           |            |                            |              |                      |                   
    123 | 14179399 |   714991 | schema3     | normal_start_finish_table      | Started                        | 1509938388 |       326450 | 2017-06-16 21:38:33.736044 | Finished                       | 965034471 |     209947 | 2017-06-16 23:18:06.95569  |    544903917 |               116503 |               5973
    123 | 14179399 |   714991 | schema3     | normal_start_finish_table      | Finished                       |  965034471 |       209947 | 2017-06-16 23:18:06.95569  |                                |           |            |                            |              |                      |                   
    123 | 14182006 |   715121 | schema3     | started_not_finished_table     | Started                        | 1199046084 |       204684 | 2017-06-16 23:40:53.50147  |                                |           |            |                            |              |                      |                   
    123 | 13209083 |  1172437 | schema4     | skipped_already_sorted_table   | Skipped(sorted>=95%)           |    1240765 |         8160 | 2017-06-05 20:57:32.436137 |                                |           |            |                            |              |                      |                   
(7 rows)
```

Example after:

```
$ redshift.sh -c 'select * from admin.v_get_vacuum_details_awb order by schema_name, table_name, start_time;'
 userid |   xid    | table_id | schema_name |       table_name               |          start_status          | start_rows | start_blocks |         start_time         |           end_status           | end_rows  | end_blocks |          end_time          | rows_deleted | blocks_deleted_added | processing_seconds 
--------+----------+----------+-------------+--------------------------------+--------------------------------+------------+--------------+----------------------------+--------------------------------+-----------+------------+----------------------------+--------------+----------------------+--------------------
    123 | 14109523 |  1330397 | schema1     | skipped_table                  | Skipped                        |          3 |           15 | 2017-06-15 17:56:08.254676 |                                |           |            |                            |              |                      |                   
    123 | 14181682 |  1000856 | schema2     | delete_only_table              | Started Delete Only (To 95%)   | 2352227448 |       895997 | 2017-06-16 23:21:12.407167 | Finished                       | 161281455 |      73704 | 2017-06-16 23:36:08.781039 |   2190945993 |               822293 |                896
    123 | 14179399 |   714991 | schema3     | normal_start_finish_table      | Started                        | 1509938388 |       326450 | 2017-06-16 21:38:33.736044 | Finished                       | 965034471 |     209947 | 2017-06-16 23:18:06.95569  |    544903917 |               116503 |               5973
    123 | 14182006 |   715121 | schema3     | started_not_finished_table     | Started                        | 1199046084 |       204684 | 2017-06-16 23:40:53.50147  |                                |           |            |                            |              |                      |                   
    123 | 13209083 |  1172437 | schema4     | skipped_already_sorted_table   | Skipped(sorted>=95%)           |    1240765 |         8160 | 2017-06-05 20:57:32.436137 |                                |           |            |                            |              |                      |                   
(5 rows)
```