### PR TITLE
[Bugfix] Fix primary key lookup

### DIFF
--- a/src/ColumnEncodingUtility/analyze-schema-compression.py
+++ b/src/ColumnEncodingUtility/analyze-schema-compression.py
@@ -299,12 +299,7 @@ WHERE
   AND att.attrelid = cl.oid
   and cl.relnamespace = pgn.oid
   and pgn.nspname = '%s'
-  and (ind.indkey[0] = att.attnum or 
-       ind.indkey[1] = att.attnum or
-       ind.indkey[2] = att.attnum or
-       ind.indkey[3] = att.attnum or
-       ind.indkey[4] = att.attnum
-      )
+  and att.attnum = ANY(string_to_array(textin(int2vectorout(ind.indkey)), ' '))
   and attnum > 0
   AND ind.indisprimary
 order by att.attnum;


### PR DESCRIPTION
The current primary key lookup is broken for tables that contain primary keys with more than 5 columns. 
indkey is an int2vector column and this seems to be the only way to lookup if attnum exists in the vector type because redshift doesn't support int2vector type.