### PR TITLE
Do not print command line arguments to stdout

### DIFF
--- a/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
+++ b/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
@@ -604,7 +604,6 @@ def main(argv):
 
     # parse command line arguments
     for arg, value in optlist:
-        print(arg,value )
         if arg == "--db":
             if value == '' or value == None:
                 usage()


### PR DESCRIPTION
I think the script shouldn't print out all command line arguments (which include redshift password). This was inadvertently introduced in the last PR