### PR TITLE
Removed 'keepalives' settings in pg8000 call

### DIFF
--- a/src/ColumnEncodingUtility/analyze-schema-compression.py
+++ b/src/ColumnEncodingUtility/analyze-schema-compression.py
@@ -185,7 +185,7 @@ def get_pg_conn():
             comment('Connect [%s] %s:%s:%s:%s' % (pid, db_host, db_port, db, db_user))
         
         try:
-            conn = pg8000.connect(user=db_user, host=db_host, port=db_port, database=db, password=db_pwd, ssl=ssl_option, timeout=None, keepalives=1, keepalives_idle=200, keepalives_interval=200, keepalives_count=5)
+            conn = pg8000.connect(user=db_user, host=db_host, port=db_port, database=db, password=db_pwd, ssl=ssl_option, timeout=None)
         except Exception as e:
             write(e)
             write('Unable to connect to Cluster Endpoint')


### PR DESCRIPTION
Got the following error message when running with the latest pg8000 (1.11.0).

connect() got an unexpected keyword argument 'keepalives'

Script runs after removing 'keepalives' settings.