### PR TITLE
ColumnEncodingUtility: Passing proper database name to pg8000

### DIFF
--- a/src/ColumnEncodingUtility/analyze-schema-compression.py
+++ b/src/ColumnEncodingUtility/analyze-schema-compression.py
@@ -173,7 +173,7 @@ def get_pg_conn():
             comment('Connect [%s] %s:%s:%s:%s' % (pid, db_host, db_port, db, db_user))
 
         try:
-            conn = pg8000.connect(user=db_user, host=db_host, port=db_port, database=db_name, password=db_pwd,
+            conn = pg8000.connect(user=db_user, host=db_host, port=db_port, database=db, password=db_pwd,
                                   ssl=ssl, timeout=None)
         except Exception as e:
             print(e)


### PR DESCRIPTION
Solves database connection problem because it was not passing the database name.

```
(u'FATAL', u'3D000', u'database "master" does not exist', u'/home/ec2-user/padb/src/pg/src/backend/utils/init/postinit.c', u'392', u'InitPostgres')
```
