### PR TITLE
Cleanups and small fixes in Column Encoding Utility

### DIFF
--- a/src/ColumnEncodingUtility/analyze-schema-compression.py
+++ b/src/ColumnEncodingUtility/analyze-schema-compression.py
@@ -127,7 +127,8 @@ def close_conn(conn):
         conn.close()
     except Exception as e:
         if debug:
-            print(e)
+            if 'connection is closed' not in str(e):
+                print(e)
 
 
 def cleanup(conn):
@@ -594,8 +595,9 @@ def analyze(table_info):
                             return ERROR
 
                         if debug:
-                            comment("Max of column '%s' for table '%s.%s' is %d. Current column type is %s." % (
-                                descr[col][0], schema_name, table_name, col_len_result[0][0], col_type))
+                            max = col_len_result[0][0] if col_len_result else 'not defined'
+                            comment("Max of column '%s' for table '%s.%s' is %s. Current column type is %s." % (
+                                descr[col][0], schema_name, table_name, max, col_type))
 
                         # Test to see if largest value is smaller than largest value of smallint (2 bytes)
                         if col_len_result[0][0] <= int(math.pow(2, 15) - 1) and col_type != "smallint":
@@ -832,7 +834,6 @@ def usage(with_message):
         '           --target-schema       - Name of a Schema into which the newly optimised tables and data should be created, rather than in place')
     print('           --threads             - The number of concurrent connections to use during analysis (default 2)')
     print('           --output-file         - The full path to the output file to be generated')
-    print('           --report-file         - The full path to the report file to be generated')
     print('           --debug               - Generate Debug Output including SQL Statements being run')
     print('           --do-execute          - Run the compression encoding optimisation')
     print('           --slot-count          - Modify the wlm_query_slot_count from the default of 1')
@@ -1043,7 +1044,7 @@ order by 2;
 
 
 def main(argv):
-    supported_args = """db= db-user= db-pwd= db-host= db-port= target-schema= analyze-schema= analyze-table= new-dist-key= new-sort-keys= analyze-cols= threads= debug= output-file= report-file= do-execute= slot-count= ignore-errors= force= drop-old-data= comprows= query_group= ssl-option= suppress-cloudwatch="""
+    supported_args = """db= db-user= db-pwd= db-host= db-port= target-schema= analyze-schema= analyze-table= new-dist-key= new-sort-keys= analyze-cols= threads= debug= output-file= do-execute= slot-count= ignore-errors= force= drop-old-data= comprows= query_group= ssl-option= suppress-cloudwatch="""
 
     # extract the command line arguments
     try:

--- a/src/bin/run-column-encoding-utility.sh
+++ b/src/bin/run-column-encoding-utility.sh
@@ -28,8 +28,9 @@ ANALYZE_TABLE=${ANALYZE_TABLE:-}
 ANALYZE_COL_WIDTH=${ANALYZE_COL_WIDTH:-}
 OUTPUT_FILE=${OUTPUT_FILE:-}
 COMP_ROWS=${COMP_ROWS:-}
-REPORT_FILE=${REPORT_FILE:-}
 QUERY_GROUP=${QUERY_GROUP:-}
+NEW_DIST_KEY=${NEW_DIST_KEY:-}
+NEW_SORT_KEYS=${NEW_SORT_KEYS:-}
 
 if [ "${DB}" == "" ]; then echo "Environment Var 'DB' must be defined"
 elif [ "${DB_USER}" == "" ]; then echo "Environment Var 'DB_USER' must be defined"
@@ -40,8 +41,9 @@ else
     if [ "${ANALYZE_COL_WIDTH}" != "" ]; then ANALYZE_COL_WIDTH_CMD="--analyze-cols ${ANALYZE_COL_WIDTH}"; fi
     if [ "${OUTPUT_FILE}" != "" ]; then OUTPUT_FILE_CMD="--output-file ${OUTPUT_FILE}"; fi
     if [ "${COMP_ROWS}" != "" ]; then COMP_ROWS_CMD="--comprows ${COMP_ROWS}"; fi
-    if [ "${REPORT_FILE}" != "" ]; then REPORT_FILE_CMD="--report-file ${REPORT_FILE}"; fi
     if [ "${QUERY_GROUP}" != "" ]; then QUERY_GROUP_CMD="--query_group ${QUERY_GROUP}"; fi
+    if [ "${NEW_DIST_KEY}" != "" ]; then NEW_DIST_KEY_CMD="--new-dist-key ${NEW_DIST_KEY}"; fi
+    if [ "${NEW_SORT_KEYS}" != "" ]; then NEW_SORT_KEYS_CMD="--new-sort-keys ${NEW_SORT_KEYS}"; fi
 
     python ColumnEncodingUtility/analyze-schema-compression.py \
         --db ${DB} \
@@ -59,7 +61,8 @@ else
         --force ${FORCE} \
         --drop-old-data ${DROP_OLD_DATA} \
         --ssl-option ${SSL_OPTION} \
-        ${ANALYZE_TABLE_CMD} ${ANALYZE_COL_WIDTH_CMD} ${OUTPUT_FILE_CMD} ${COMP_ROWS_CMD} ${REPORT_FILE_CMD} ${QUERY_GROUP_CMD}
+        ${ANALYZE_TABLE_CMD} ${ANALYZE_COL_WIDTH_CMD} ${OUTPUT_FILE_CMD} ${COMP_ROWS_CMD} ${QUERY_GROUP_CMD} \
+        ${NEW_DIST_KEY_CMD} ${NEW_SORT_KEYS_CMD}
 
     echo "Done"
 fi


### PR DESCRIPTION
1. bin/run-column-encoding-utility.sh supports --new-dist-key and --new-sort-keys arguments.
2. bin/run-column-encoding-utility.sh removed unsupported --report-file argument.
3. analyze-schema-compression.py doesn't output `connection is closed` if debug is enabled.
4. analyze-schema-compression.py doesn't generate error on empty columns of numeric types if debug is enabled.
5. analyze-schema-compression.py removed documentation for unsupported --report-file argument.