### PR TITLE
Remove remaining references to deleted_pct for the vacuum utility

### DIFF
--- a/src/AnalyzeVacuumUtility/README.md
+++ b/src/AnalyzeVacuumUtility/README.md
@@ -81,7 +81,7 @@ Run ANALYZE based the `stats_off` metric in `svv_table_info`. If table has a `st
 |--max-table-size-mb | No | 700*1024 |
 |--predicate-cols | No | False |
 
-The above parameter values depend on the cluster type, table size, available system resources and available ‘Time window’ etc. The default values provided here are based on ds2.8xlarge, 8 node cluster. It may take some trial and error to come up with correct parameter values to vacuum and analyze your table(s). If table size is greater than certain size (`max_table_size_mb`) and has a large unsorted region (`deleted_pct` or `max_unsorted_pct`), consider performing a deep copy, which will be much faster than a vacuum.
+The above parameter values depend on the cluster type, table size, available system resources and available ‘Time window’ etc. The default values provided here are based on ds2.8xlarge, 8 node cluster. It may take some trial and error to come up with correct parameter values to vacuum and analyze your table(s). If table size is greater than certain size (`max_table_size_mb`) and has a large unsorted region (`max_unsorted_pct`), consider performing a deep copy, which will be much faster than a vacuum.
 
 As VACUUM & ANALYZE operations are resource intensive, you should ensure that this will not adversely impact other database operations running on your cluster. AWS has thoroughly tested this software on a variety of systems, but cannot be responsible for the impact of running the utility against your database.
 

--- a/src/AnalyzeVacuumUtility/lib/analyze_vacuum.py
+++ b/src/AnalyzeVacuumUtility/lib/analyze_vacuum.py
@@ -317,11 +317,11 @@ def run_vacuum(conn,
                                         WHERE "schema" = '%s'
                                                 AND
                                                  (
-                                                --If the size of the table is less than the max_table_size_mb then , run vacuum based on condition: >min_unsorted_pct AND >deleted_pct
+                                                --If the size of the table is less than the max_table_size_mb then , run vacuum based on condition: >min_unsorted_pct
                                                     ((size < %s) AND (unsorted > %s or stats_off > %s))
                                                     OR
                                                 --If the size of the table is greater than the max_table_size_mb then , run vacuum based on condition:
-                                                -- >min_unsorted_pct AND < max_unsorted_pct AND >deleted_pct
+                                                -- >min_unsorted_pct AND < max_unsorted_pct
                                                 --This is to avoid big table with large unsorted_pct
                                                      ((size > %s) AND (unsorted > %s AND unsorted < %s ))
                                                  )

--- a/src/RedshiftAutomation/README.md
+++ b/src/RedshiftAutomation/README.md
@@ -82,7 +82,6 @@ You can also add the following configuration options to finely tune the operatio
 "vacuum_parameter": "Vacuum type to be run, including FULL, SORT ONLY, DELETE ONLY, REINDEX (default FULL)",
 "min_unsorted_pct": "Minimum unsorted percentage(%) to consider a table for vacuum (default 5%)",
 "max_unsorted_pct": "Maximum unsorted percentage(%) to consider a table for vacuum (default 50%)",
-"deleted_pct": "Minimum deleted percentage (%) to consider a table for vacuum (default 5%)",
 "stats_off_pct": "Minimum stats off percentage(%) to consider a table for analyze (default 10%)",
 "predicate_cols": "Flag to enforce only analyzing predicate columns (see http://bit.ly/2o163tC)",
 "suppress_cw": "Set to true to suppress utilities exporting CloudWatch metrics",

--- a/src/bin/run-analyze-vacuum-utility.sh
+++ b/src/bin/run-analyze-vacuum-utility.sh
@@ -23,7 +23,6 @@ VACUUM_FLAG=${VACUUM_FLAG:-true}
 VACUUM_PARAMETER=${VACUUM_PARAMETER:-full}
 MIN_UNSORTED_PCT=${MIN_UNSORTED_PCT:-5}
 MAX_UNSORTED_PCT=${MAX_UNSORTED_PCT:-50}
-DELETED_PCT=${DELETED_PCT:-5}
 STATS_OFF_PCT=${STATS_OFF_PCT:-10}
 PREDICATE_COLS=${PREDICATE_COLS:-false}
 MAX_TABLE_SIZE_MB=${MAX_TABLE_SIZE_MB:-(700*1024)}
@@ -65,7 +64,6 @@ else
         --vacuum-parameter ${VACUUM_PARAMETER} \
         --min-unsorted-pct ${MIN_UNSORTED_PCT} \
         --max-unsorted-pct ${MAX_UNSORTED_PCT} \
-        --deleted-pct ${DELETED_PCT} \
         --stats-off-pct ${STATS_OFF_PCT} \
         --predicate-cols ${PREDICATE_COLS} \
         --max-table-size-mb ${MAX_TABLE_SIZE_MB} \

--- a/src/config_constants.py
+++ b/src/config_constants.py
@@ -28,7 +28,6 @@ AGG_INTERVAL = "agg_interval"
 VACUUM_PARAMETER = "vacuum_parameter"
 MIN_UNSORTED_PCT = "min_unsorted_pct"
 MAX_UNSORTED_PCT = "max_unsorted_pct"
-DELETED_PCT = "deleted_pct"
 STATS_OFF_PCT = "stats_off_pct"
 PREDICATE_COLS = "predicate_cols"
 SUPPRESS_CLOUDWATCH = "suppress_cw"
@@ -99,7 +98,6 @@ def normalise_config(config):
     add_to_config(VACUUM_PARAMETER)
     add_to_config(MIN_UNSORTED_PCT)
     add_to_config(MAX_UNSORTED_PCT)
-    add_to_config(DELETED_PCT)
     add_to_config(STATS_OFF_PCT)
     add_to_config(PREDICATE_COLS)
     add_to_config(SUPPRESS_CLOUDWATCH)


### PR DESCRIPTION
This pull request removes the remaining references to  `deleted_pct` which was removed in this commit (41423bfa627970c62e3d89ae3cc8be5a555895e2).

The majority of these are documentation references but the reference in `src/bin/run-analyze-vacuum-utility.sh` breaks the script.