### PR TITLE
Adapt views that generate statements to use QUOTE_IDENT for identifiers

### DIFF
--- a/src/AdminViews/v_find_dropuser_objs.sql
+++ b/src/AdminViews/v_find_dropuser_objs.sql
@@ -17,6 +17,7 @@ History:
 2017-03-27 adedotua created
 2017-04-06 adedotua improvements
 2018-01-06 adedotua added ddl column to generate ddl for transferring object ownership
+2018-01-15 pvbouwel Add QUOTE_IDENT for identifiers
 **********************************************************************************************/
 
 CREATE OR REPLACE VIEW admin.v_find_dropuser_objs as 
@@ -29,7 +30,7 @@ SELECT owner.objtype,
 FROM (
 -- Functions owned by the user
      SELECT 'Function',pgu.usename,pgu.usesysid,nc.nspname,textin (regprocedureout (pproc.oid::regprocedure)),
-     'alter function ' ||nc.nspname|| '.' ||textin (regprocedureout (pproc.oid::regprocedure)) || ' owner to ' 
+     'alter function ' || QUOTE_IDENT(nc.nspname) || '.' ||textin (regprocedureout (pproc.oid::regprocedure)) || ' owner to ' 
      FROM pg_proc pproc,pg_user pgu,pg_namespace nc
 WHERE pproc.pronamespace = nc.oid
 AND   pproc.proowner = pgu.usesysid
@@ -40,7 +41,7 @@ SELECT 'Database',
        pgu.usesysid,
        NULL,
        pgd.datname,
-       'alter database ' ||pgd.datname|| ' owner to '
+       'alter database ' || QUOTE_IDENT(pgd.datname) || ' owner to '
 FROM pg_database pgd,
      pg_user pgu
 WHERE pgd.datdba = pgu.usesysid
@@ -51,7 +52,7 @@ SELECT 'Schema',
        pgu.usesysid,
        NULL,
        pgn.nspname,
-       'alter schema '||pgn.nspname||' owner to '
+       'alter schema '|| QUOTE_IDENT(pgn.nspname) ||' owner to '
 FROM pg_namespace pgn,
      pg_user pgu
 WHERE pgn.nspowner = pgu.usesysid
@@ -65,7 +66,7 @@ SELECT decode(pgc.relkind,
        pgu.usesysid,
        nc.nspname,
        pgc.relname,
-       'alter table ' ||nc.nspname|| '.' ||pgc.relname|| ' owner to '
+       'alter table ' || QUOTE_IDENT(nc.nspname) || '.' || QUOTE_IDENT(pgc.relname) || ' owner to '
 FROM pg_class pgc,
      pg_user pgu,
      pg_namespace nc

--- a/src/AdminViews/v_generate_group_ddl.sql
+++ b/src/AdminViews/v_generate_group_ddl.sql
@@ -3,10 +3,11 @@
 Purpose: View to get the DDL for a group.  
 History:
 2014-02-11 jjschmit Created
+2018-01-15 pvbouwel Add QUOTE_IDENT for group names
 **********************************************************************************************/
 CREATE OR REPLACE VIEW admin.v_generate_group_ddl
 AS
-SELECT groname AS groupname, 'CREATE GROUP "' + groname + '";' AS ddl FROM pg_catalog.pg_group ORDER BY groname
+SELECT groname AS groupname, 'CREATE GROUP ' + QUOTE_IDENT(groname) + ';' AS ddl FROM pg_catalog.pg_group ORDER BY groname
 ;
 
 

--- a/src/AdminViews/v_generate_schema_ddl.sql
+++ b/src/AdminViews/v_generate_schema_ddl.sql
@@ -3,10 +3,11 @@
 Purpose: View to get the DDL for schemas.  
 History:
 2014-02-11 jjschmit Created
+2018-01-15 pvbouwel Add QUOTE_IDENT for namespace literal
 **********************************************************************************************/
 CREATE OR REPLACE VIEW admin.v_generate_schema_ddl
 AS
-SELECT nspname AS schemaname, 'CREATE SCHEMA "' + nspname + '";' AS ddl FROM pg_catalog.pg_namespace WHERE nspowner >= 100 ORDER BY nspname
+SELECT nspname AS schemaname, 'CREATE SCHEMA ' + QUOTE_IDENT(nspname) + ';' AS ddl FROM pg_catalog.pg_namespace WHERE nspowner >= 100 ORDER BY nspname
 ;
 
 

--- a/src/AdminViews/v_generate_udf_ddl.sql
+++ b/src/AdminViews/v_generate_udf_ddl.sql
@@ -3,6 +3,7 @@
 Purpose: View to get the DDL for a UDF. 
 History:
 2016-04-20 chriz-bigdata Created
+2018-01-15 pvbouwel Add QUOTE_IDENT for identifiers (function name)
 **********************************************************************************************/
 CREATE OR REPLACE VIEW admin.v_generate_udf_ddl
 AS
@@ -20,7 +21,7 @@ SELECT
    n.nspname AS schemaname,
    p.proname AS udfname,
    p.oid AS udfoid,
-1000 as seq, ('CREATE FUNCTION ' || p.proname || ' \(')::varchar(max) as ddl
+1000 as seq, ('CREATE FUNCTION ' || QUOTE_IDENT(p.proname) || ' \(')::varchar(max) as ddl
 FROM pg_proc p
 LEFT JOIN pg_namespace n on n.oid = p.pronamespace
 WHERE p.proowner != 1

--- a/src/AdminViews/v_generate_user_grant_revoke_ddl.sql
+++ b/src/AdminViews/v_generate_user_grant_revoke_ddl.sql
@@ -1,36 +1,37 @@
 /*************************************************************************************************************************
-Purpose:        View to generate grant or revoke ddl for users and groups. This is useful for 
-		recreating users or group privileges or for revoking privileges before dropping 
-		a user or group
-		
+Purpose:      View to generate grant or revoke ddl for users and groups. This is useful for 
+              recreating users or group privileges or for revoking privileges before dropping 
+              a user or group
+              
 Columns -
-objowner:       Object owner 
-schemaname:	Object schema if applicable
-objname:	Name of the object the privilege is granted on
-grantor:        User that granted the privilege
-username:       User/Group the privilege is granted to
-objtype:        Type of object user has privilege on. Object types are Function,Schema,
-                Table or View, Database, Language or Default ACL
-ddltype:        Type of ddl generated i.e grant or revoke
-sequence:	Sequence number to order the DDLs by hierarchy
-ddl:            DDL text
+objowner:     Object owner 
+schemaname:   Object schema if applicable
+objname:      Name of the object the privilege is granted on
+grantor:      User that granted the privilege
+username:     User/Group the privilege is granted to
+objtype:      Type of object user has privilege on. Object types are Function,Schema,
+              Table or View, Database, Language or Default ACL
+ddltype:      Type of ddl generated i.e grant or revoke
+sequence:     Sequence number to order the DDLs by hierarchy
+ddl:          DDL text
 Notes:           
                 
 History:
-2017-07-11 	adedotua created
-2017-07-17 	adedotua added comments to account for difference between grantor and owner of 
-		object. Also added schemaname and objname columns.
-2017-12-17	adedotua added sequence column to order grant or revoke DDLs in order of heirarchy.
-2017-12-17	adedotua added schema name admin
-2017-12-18	adedotua added case statement for revoke DDLs to account for situations where the grantor is not object owner 
-		
-		
-		
+2017-07-11    adedotua created
+2017-07-17    adedotua added comments to account for difference between grantor and owner of 
+              object. Also added schemaname and objname columns.
+2017-12-17    adedotua added sequence column to order grant or revoke DDLs in order of heirarchy.
+2017-12-17    adedotua added schema name admin
+2017-12-18    adedotua added case statement for revoke DDLs to account for situations where the grantor is not object owner 
+2018-01-15    pvbouwel Add QUOTE_IDENT for identifiers (schema,table and column names)
+              
+              
+              
 Steps to revoking grants before dropping a user:
 1. Find all grants by granted by user to drop and regrant them as another user (superuser preferably).
 select ddl from v_generate_user_grant_revoke_ddl where grantor='<username>' and ddltype='grant' and objtype <>'Default ACL' order by sequence;
 2. Find all grants granted to user to drop and revoke them.
-select ddl from v_generate_user_grant_revoke_ddl where ddltype='revoke' and (username='<username>' or grantor='<username>') order by sequence;		
+select ddl from v_generate_user_grant_revoke_ddl where ddltype='revoke' and (username='<username>' or grantor='<username>') order by sequence;              
 ************************************************************************************************************************/
 
 CREATE OR REPLACE VIEW admin.v_generate_user_grant_revoke_ddl as
@@ -62,8 +63,8 @@ SELECT 'USAGE'::character varying as type)
 select * from (
 -- Functions grants
 select pg_get_userbyid(c.proowner),sc.nspname,textin(regprocedureout(c.oid::regprocedure)),g.usename,u.usename,'Function','grant',2,
-'grant execute on function '||sc.nspname||'.'||textin(regprocedureout(c.oid::regprocedure))||
-CASE WHEN u.usesysid>1 THEN ' to ' ELSE ' to group ' END||u.usename||
+'grant execute on function '|| QUOTE_IDENT(sc.nspname)||'.'||textin(regprocedureout(c.oid::regprocedure))||
+CASE WHEN u.usesysid>1 THEN ' to ' ELSE ' to group ' END||QUOTE_IDENT(u.usename)||
 CASE WHEN aclcontains(c.proacl, makeaclitem(u.usesysid,u.grosysid,g.usesysid,'EXECUTE',true)) THEN ' with grant option;' ELSE ';' END::text
 from pg_proc c join schemas sc on c.pronamespace=sc.oid,grantor g,grantee u
 where  aclcontains(c.proacl, makeaclitem(u.usesysid,u.grosysid,g.usesysid,'EXECUTE',false))
@@ -71,9 +72,9 @@ UNION ALL
 -- Functions revokes
 select pg_get_userbyid(c.proowner),sc.nspname,textin(regprocedureout(c.oid::regprocedure)),g.usename,u.usename,'Function','revoke',
 CASE WHEN (g.usename <> current_user and g.usename <> pg_get_userbyid(c.proowner) and g.usename <> 'rdsdb') THEN 1::int ELSE 2::int END,
-CASE WHEN (g.usename <> current_user and g.usename <> pg_get_userbyid(c.proowner) and g.usename <> 'rdsdb') THEN 'set session authorization '||g.usename||'; ' ELSE '' END::text||
-'revoke execute on function '||sc.nspname||'.'||textin(regprocedureout(c.oid::regprocedure))||
-CASE WHEN u.usesysid>1 THEN ' from ' ELSE ' from group ' END||u.usename||';'||
+CASE WHEN (g.usename <> current_user and g.usename <> pg_get_userbyid(c.proowner) and g.usename <> 'rdsdb') THEN 'set session authorization '||QUOTE_IDENT(g.usename)||'; ' ELSE '' END::text||
+'revoke execute on function '||QUOTE_IDENT(sc.nspname)||'.'||textin(regprocedureout(c.oid::regprocedure))||
+CASE WHEN u.usesysid>1 THEN ' from ' ELSE ' from group ' END||QUOTE_IDENT(u.usename)||';'||
 CASE WHEN (g.usename <> current_user and g.usename <> pg_get_userbyid(c.proowner) and g.usename <> 'rdsdb') THEN 'reset session authorization;' ELSE '' END::text 
 from pg_proc c join schemas sc on c.pronamespace=sc.oid,grantor g,grantee u
 where  aclcontains(c.proacl, makeaclitem(u.usesysid,u.grosysid,g.usesysid,'EXECUTE',false)) 
@@ -81,7 +82,7 @@ UNION ALL
 -- Language grants
 select null,null,c.lanname,g.usename,u.usename,'Language','grant',1,
 'grant usage on language '||c.lanname||
-CASE WHEN u.usesysid>1 THEN ' to ' ELSE ' to group ' END||u.usename||
+CASE WHEN u.usesysid>1 THEN ' to ' ELSE ' to group ' END||QUOTE_IDENT(u.usename)||
 CASE WHEN aclcontains(c.lanacl, makeaclitem(u.usesysid,u.grosysid,g.usesysid,'USAGE',true)) THEN ' with grant option;' ELSE ';' END::text
 from pg_language c,grantor g,grantee u
 where aclcontains(c.lanacl, makeaclitem(u.usesysid,u.grosysid,g.usesysid,'USAGE',false)) 
@@ -89,17 +90,17 @@ UNION ALL
 -- Language revokes
 select null,null,c.lanname,g.usename,u.usename,'Language','revoke',
 CASE WHEN (g.usename <> current_user and g.usename <> 'rdsdb') THEN 2::int ELSE 3::int END,
-CASE WHEN (g.usename <> current_user and g.usename <> 'rdsdb') THEN 'set session authorization '||g.usename||'; ' ELSE '' END::text||
+CASE WHEN (g.usename <> current_user and g.usename <> 'rdsdb') THEN 'set session authorization '||QUOTE_IDENT(g.usename)||'; ' ELSE '' END::text||
 'revoke usage on language '||c.lanname||
-CASE WHEN u.usesysid>1 THEN ' from ' ELSE ' from group ' END||u.usename||';'||
+CASE WHEN u.usesysid>1 THEN ' from ' ELSE ' from group ' END||QUOTE_IDENT(u.usename)||';'||
 CASE WHEN (g.usename <> current_user and g.usename <> 'rdsdb') THEN 'reset session authorization;' ELSE '' END::text 
 from pg_language c,grantor g,grantee u
 where aclcontains(c.lanacl, makeaclitem(u.usesysid,u.grosysid,g.usesysid,'USAGE',false)) 
 UNION ALL
 --Tables grants
 select pg_get_userbyid(c.relowner),sc.nspname,c.relname,g.usename,u.usename,case c.relkind WHEN 'r' THEN 'Table' WHEN 'v' THEN 'View' END,'grant',2,
-'grant '||t.type||' on '||sc.nspname||'.'||c.relname||
-CASE WHEN u.usesysid>1 THEN ' to ' ELSE ' to group ' END||u.usename||
+'grant '||t.type||' on '||QUOTE_IDENT(sc.nspname)||'.'||QUOTE_IDENT(c.relname)||
+CASE WHEN u.usesysid>1 THEN ' to ' ELSE ' to group ' END||QUOTE_IDENT(u.usename)||
 CASE WHEN aclcontains(c.relacl, makeaclitem(u.usesysid,u.grosysid,g.usesysid,t.type,true)) THEN ' with grant option;' ELSE ';' END::text
 from pg_class c join schemas sc on c.relnamespace=sc.oid, grantor g,grantee u,tabprivs t
 where aclcontains(c.relacl, makeaclitem(u.usesysid,u.grosysid,g.usesysid,t.type,false)) 
@@ -107,9 +108,9 @@ UNION ALL
 --Tables revokes
 select distinct pg_get_userbyid(c.relowner),sc.nspname,c.relname,g.usename,u.usename,'Table/View','revoke',
 CASE WHEN (g.usename <> current_user and g.usename <> pg_get_userbyid(c.relowner) and g.usename <> 'rdsdb') THEN 1::int ELSE 2::int END,
-CASE WHEN (g.usename <> current_user and g.usename <> pg_get_userbyid(c.relowner) and g.usename <> 'rdsdb') THEN 'set session authorization '||g.usename||'; ' ELSE '' END::text||
-'revoke all on '||sc.nspname||'.'||c.relname||
-CASE WHEN u.usesysid>1 THEN ' from ' ELSE ' from group ' END||u.usename||';'||
+CASE WHEN (g.usename <> current_user and g.usename <> pg_get_userbyid(c.relowner) and g.usename <> 'rdsdb') THEN 'set session authorization '||QUOTE_IDENT(g.usename)||'; ' ELSE '' END::text||
+'revoke all on '||QUOTE_IDENT(sc.nspname)||'.'||QUOTE_IDENT(c.relname)||
+CASE WHEN u.usesysid>1 THEN ' from ' ELSE ' from group ' END||QUOTE_IDENT(u.usename)||';'||
 CASE WHEN (g.usename <> current_user and g.usename <> pg_get_userbyid(c.relowner) and g.usename <> 'rdsdb') THEN 'reset session authorization;' ELSE '' END::text 
 from pg_class c join schemas sc on c.relnamespace=sc.oid, grantor g,grantee u
 where EXISTS (
@@ -125,8 +126,8 @@ select 1 WHERE aclcontains(c.relacl, makeaclitem(u.usesysid,u.grosysid,g.usesysi
 UNION ALL
 -- Schema grants
 select pg_get_userbyid(c.nspowner),null,c.nspname,g.usename,u.usename,'Schema','grant',1,
-'grant '||s.type||' on schema '||c.nspname||
-CASE WHEN u.usesysid>1 THEN ' to ' ELSE ' to group ' END||u.usename||
+'grant '||s.type||' on schema '||QUOTE_IDENT(c.nspname)||
+CASE WHEN u.usesysid>1 THEN ' to ' ELSE ' to group ' END||QUOTE_IDENT(u.usename)||
 CASE WHEN aclcontains(c.nspacl, makeaclitem(u.usesysid,u.grosysid,g.usesysid,s.type,true)) THEN ' with grant option;' ELSE ';' END::text
 from pg_namespace c, grantor g,grantee u,schemaprivs s
 where  aclcontains(c.nspacl, makeaclitem(u.usesysid,u.grosysid,g.usesysid,s.type,false))
@@ -134,9 +135,9 @@ UNION ALL
 -- Schema revokes
 select pg_get_userbyid(c.nspowner),null,c.nspname,g.usename,u.usename,'Schema','revoke',
 CASE WHEN (g.usename <> current_user and g.usename <> pg_get_userbyid(c.nspowner) and g.usename <> 'rdsdb') THEN 2::int ELSE 3::int END,
-CASE WHEN (g.usename <> current_user and g.usename <> pg_get_userbyid(c.nspowner) and g.usename <> 'rdsdb') THEN 'set session authorization '||g.usename||'; ' ELSE '' END::text||
-'revoke all on schema '||c.nspname||
-CASE WHEN u.usesysid>1 THEN ' from ' ELSE ' from group ' END||u.usename||';'||
+CASE WHEN (g.usename <> current_user and g.usename <> pg_get_userbyid(c.nspowner) and g.usename <> 'rdsdb') THEN 'set session authorization '||QUOTE_IDENT(g.usename)||'; ' ELSE '' END::text||
+'revoke all on schema '||QUOTE_IDENT(c.nspname)||
+CASE WHEN u.usesysid>1 THEN ' from ' ELSE ' from group ' END||QUOTE_IDENT(u.usename)||';'||
 CASE WHEN (g.usename <> current_user and g.usename <> pg_get_userbyid(c.nspowner) and g.usename <> 'rdsdb') THEN 'reset session authorization;' ELSE '' END::text 
 from pg_namespace c, grantor g,grantee u
 where  exists 
@@ -146,8 +147,8 @@ select 1 where aclcontains(c.nspacl, makeaclitem(u.usesysid,u.grosysid,g.usesysi
 UNION ALL
 -- Database grants
 select pg_get_userbyid(c.datdba),null,c.datname,g.usename,u.usename,'Database','grant',0,
-'grant '||d.type||' on database '||c.datname||
-CASE WHEN u.usesysid>1 THEN ' to ' ELSE ' to group ' END||u.usename||
+'grant '||d.type||' on database '||QUOTE_IDENT(c.datname)||
+CASE WHEN u.usesysid>1 THEN ' to ' ELSE ' to group ' END||QUOTE_IDENT(u.usename)||
 CASE WHEN aclcontains(c.datacl, makeaclitem(u.usesysid,u.grosysid,g.usesysid,d.type,true)) THEN ' with grant option;' ELSE ';' END::text 
 from pg_database c, grantor g,grantee u,dbprivs d
 where  aclcontains(c.datacl, makeaclitem(u.usesysid,u.grosysid,g.usesysid,d.type,false))
@@ -155,9 +156,9 @@ UNION ALL
 -- Database revokes
 select pg_get_userbyid(c.datdba),null,c.datname,g.usename,u.usename,'Database','revoke',
 CASE WHEN (g.usename <> current_user and g.usename <> pg_get_userbyid(c.datdba) and g.usename <> 'rdsdb') THEN 3::int ELSE 4::int END,
-CASE WHEN (g.usename <> current_user and g.usename <> pg_get_userbyid(c.datdba) and g.usename <> 'rdsdb') THEN 'set session authorization '||g.usename||'; ' ELSE '' END::text||
-'revoke all on database '||c.datname||
-CASE WHEN u.usesysid>1 THEN ' from ' ELSE ' from group ' END||u.usename||';'||
+CASE WHEN (g.usename <> current_user and g.usename <> pg_get_userbyid(c.datdba) and g.usename <> 'rdsdb') THEN 'set session authorization '||QUOTE_IDENT(g.usename)||'; ' ELSE '' END::text||
+'revoke all on database '||QUOTE_IDENT(c.datname)||
+CASE WHEN u.usesysid>1 THEN ' from ' ELSE ' from group ' END||QUOTE_IDENT(u.usename)||';'||
 CASE WHEN (g.usename <> current_user and g.usename <> pg_get_userbyid(c.datdba) and g.usename <> 'rdsdb') THEN 'reset session authorization;' ELSE '' END::text 
 from pg_database c, grantor g,grantee u 
 where  exists 
@@ -167,20 +168,20 @@ select 1 where aclcontains(c.datacl, makeaclitem(u.usesysid,u.grosysid,g.usesysi
 UNION ALL
 -- Default ACL grants
 select pg_get_userbyid(c.defacluser),sc.nspname,decode(c.defaclobjtype,'r','Tables','f','Functions'),g.usename,u.usename,'Default ACL','grant',3,
-'alter default privileges for user '||pg_get_userbyid(c.defacluser)||
-CASE WHEN c.defaclnamespace >0 THEN ' in schema '||sc.nspname ELSE '' END||
+'alter default privileges for user '||QUOTE_IDENT(pg_get_userbyid(c.defacluser))||
+CASE WHEN c.defaclnamespace >0 THEN ' in schema '||QUOTE_IDENT(sc.nspname) ELSE '' END||
 ' grant '||t.type||' on '||decode(c.defaclobjtype,'r','tables','f','functions')||
-CASE WHEN u.usesysid>1 THEN ' to ' ELSE ' to group ' END||u.usename||
+CASE WHEN u.usesysid>1 THEN ' to ' ELSE ' to group ' END||QUOTE_IDENT(u.usename)||
 CASE WHEN aclcontains(c.defaclacl, makeaclitem(u.usesysid,u.grosysid,g.usesysid,t.type,true)) THEN ' with grant option;' ELSE ';' END::text
 from pg_default_acl c left join schemas sc on c.defaclnamespace=sc.oid, grantor g,grantee u,tabprivs t
 where  aclcontains(c.defaclacl, makeaclitem(u.usesysid,u.grosysid,g.usesysid,t.type,false))
 UNION ALL
 -- Default ACL revokes
 select pg_get_userbyid(c.defacluser),sc.nspname,decode(c.defaclobjtype,'r','Tables','f','Functions'),g.usename,u.usename,'Default ACL','revoke',0,
-'alter default privileges for user '||pg_get_userbyid(c.defacluser)||
-CASE WHEN c.defaclnamespace >0 THEN ' in schema '||sc.nspname ELSE '' END||
+'alter default privileges for user '||QUOTE_IDENT(pg_get_userbyid(c.defacluser))||
+CASE WHEN c.defaclnamespace >0 THEN ' in schema '||QUOTE_IDENT(sc.nspname) ELSE '' END||
 ' revoke all on '||decode(c.defaclobjtype,'r','tables','f','functions')||
-CASE WHEN u.usesysid>1 THEN ' from ' ELSE ' from group ' END||u.usename||';'::text 
+CASE WHEN u.usesysid>1 THEN ' from ' ELSE ' from group ' END||QUOTE_IDENT(u.usename)||';'::text 
 from pg_default_acl c left join schemas sc on c.defaclnamespace=sc.oid, grantor g,grantee u 
 where  EXISTS (
 select 1 WHERE aclcontains(c.defaclacl, makeaclitem(u.usesysid,u.grosysid,g.usesysid,'SELECT',false))
@@ -195,17 +196,17 @@ select 1 WHERE aclcontains(c.defaclacl, makeaclitem(u.usesysid,u.grosysid,g.uses
 UNION ALL
 select 1 WHERE aclcontains(c.defaclacl, makeaclitem(u.usesysid,u.grosysid,g.usesysid,'EXECUTE',false)))
 and pg_get_userbyid(c.defacluser)<>u.usename
-and array_to_string(c.defaclacl,'')<>('=X/'||pg_get_userbyid(c.defacluser))
+and array_to_string(c.defaclacl,'')<>('=X/'||QUOTE_IDENT(pg_get_userbyid(c.defacluser)))
 UNION ALL
 --Default ACL grants with empty acl
 select pg_get_userbyid(c.defacluser),sc.nspname,decode(c.defaclobjtype,'r','Tables','f','Functions'),null,pg_get_userbyid(c.defacluser),'Default ACL','revoke',0,
-'alter default privileges for user '||pg_get_userbyid(c.defacluser)||
-CASE WHEN c.defaclnamespace >0 THEN ' in schema '||sc.nspname ELSE '' END||
+'alter default privileges for user '||QUOTE_IDENT(pg_get_userbyid(c.defacluser))||
+CASE WHEN c.defaclnamespace >0 THEN ' in schema '||QUOTE_IDENT(sc.nspname) ELSE '' END||
 ' grant all on '||
-CASE WHEN c.defaclobjtype='r' THEN 'tables to '||pg_get_userbyid(c.defacluser)||';'
-WHEN c.defaclobjtype='f' THEN 'functions to '||pg_get_userbyid(c.defacluser)||',public;' END::text
+CASE WHEN c.defaclobjtype='r' THEN 'tables to '||QUOTE_IDENT(pg_get_userbyid(c.defacluser))||';'
+WHEN c.defaclobjtype='f' THEN 'functions to '||QUOTE_IDENT(pg_get_userbyid(c.defacluser))||',public;' END::text
 from pg_default_acl c left join schemas sc on c.defaclnamespace=sc.oid
 where EXISTS (select 1 where c.defaclacl='{}'::aclitem[]
 UNION ALL
-select 1 WHERE array_to_string(c.defaclacl,'')=('=X/'||pg_get_userbyid(c.defacluser)))
+select 1 WHERE array_to_string(c.defaclacl,'')=('=X/'||QUOTE_IDENT(pg_get_userbyid(c.defacluser))))
 )userddl("objowner","schemaname","objname","grantor","username","objtype","ddltype","sequence","ddl") where (username<>objowner or objtype='Default ACL' or objowner is null or grantor is null) and username<>'rdsdb';

--- a/src/AdminViews/v_generate_user_object_permissions.sql
+++ b/src/AdminViews/v_generate_user_object_permissions.sql
@@ -1,20 +1,20 @@
 --DROP VIEW admin.v_generate_user_object_permissions;
 /**********************************************************************************************
-Purpose: View to get the DDL for a users permissions to tables and views.  
+Purpose: View to get the DDL for a users permissions to tables and views.
 History:
 2014-02-12 jjschmit Created
+2018-01-15 pvbouwel Replace tabs with spaces and add QUOTE_IDENT for usernames
 **********************************************************************************************/
 CREATE OR REPLACE VIEW admin.v_generate_user_object_permissions
 AS
-SELECT 
-	schemaname
-	,objectname
-	,usename
-	,REVERSE(SUBSTRING(REVERSE(CASE WHEN sel IS TRUE THEN 'GRANT SELECT ON ' + QUOTE_IDENT(schemaname) + '.' + QUOTE_IDENT(objectname) + ' TO ' + usename + ';\n' ELSE '' END +
-		CASE WHEN ins IS TRUE THEN 'GRANT INSERT ON ' + QUOTE_IDENT(schemaname) + '.' + QUOTE_IDENT(objectname) + ' TO ' + usename + ';\n' ELSE '' END +
-		CASE WHEN upd IS TRUE THEN 'GRANT UPDATE ON ' + QUOTE_IDENT(schemaname) + '.' + QUOTE_IDENT(objectname) + ' TO ' + usename + ';\n' ELSE '' END +
-		CASE WHEN del IS TRUE THEN 'GRANT DELETE ON ' + QUOTE_IDENT(schemaname) + '.' + QUOTE_IDENT(objectname) + ' TO ' + usename + ';\n' ELSE '' END +
-		CASE WHEN ref IS TRUE THEN 'GRANT REFERENCES ON ' + QUOTE_IDENT(schemaname) + '.' + QUOTE_IDENT(objectname) + ' TO ' + usename + ';\n' ELSE '' END), 2)) AS ddl
-FROM
-	admin.v_get_obj_priv_by_user
+SELECT
+  schemaname
+  ,objectname
+  ,usename
+  ,REVERSE(SUBSTRING(REVERSE(CASE WHEN sel IS TRUE THEN 'GRANT SELECT ON ' + QUOTE_IDENT(schemaname) + '.' + QUOTE_IDENT(objectname) + ' TO ' + QUOTE_IDENT(usename) + ';\n' ELSE '' END +
+    CASE WHEN ins IS TRUE THEN 'GRANT INSERT ON ' + QUOTE_IDENT(schemaname) + '.' + QUOTE_IDENT(objectname) + ' TO ' + QUOTE_IDENT(usename) + ';\n' ELSE '' END +
+    CASE WHEN upd IS TRUE THEN 'GRANT UPDATE ON ' + QUOTE_IDENT(schemaname) + '.' + QUOTE_IDENT(objectname) + ' TO ' + QUOTE_IDENT(usename) + ';\n' ELSE '' END +
+    CASE WHEN del IS TRUE THEN 'GRANT DELETE ON ' + QUOTE_IDENT(schemaname) + '.' + QUOTE_IDENT(objectname) + ' TO ' + QUOTE_IDENT(usename) + ';\n' ELSE '' END +
+    CASE WHEN ref IS TRUE THEN 'GRANT REFERENCES ON ' + QUOTE_IDENT(schemaname) + '.' + QUOTE_IDENT(objectname) + ' TO ' + QUOTE_IDENT(usename) + ';\n' ELSE '' END), 2)) AS ddl
+FROM admin.v_get_obj_priv_by_user
 ;

--- a/src/AdminViews/v_generate_view_ddl.sql
+++ b/src/AdminViews/v_generate_view_ddl.sql
@@ -3,17 +3,19 @@
 Purpose: View to get the DDL for a view.  
 History:
 2014-02-10 jjschmit Created
+2018-01-15 pvbouwel Replace tabs and add QUOTE_IDENT for identifiers (schema and view names)
 **********************************************************************************************/
 CREATE OR REPLACE VIEW admin.v_generate_view_ddl
 AS
 SELECT 
-	n.nspname AS schemaname
-	,c.relname AS viewname
-	,'--DROP VIEW ' + n.nspname + '.' + c.relname + ';\nCREATE OR REPLACE VIEW ' + n.nspname + '.' + c.relname + ' AS\n' + COALESCE(pg_get_viewdef(c.oid, TRUE), '') AS ddl
+    n.nspname AS schemaname
+    ,c.relname AS viewname
+    ,'--DROP VIEW ' + QUOTE_IDENT(n.nspname) + '.' + QUOTE_IDENT(c.relname) + ';\n'
+    + 'CREATE OR REPLACE VIEW ' + QUOTE_IDENT(n.nspname) + '.' + QUOTE_IDENT(c.relname) + ' AS\n' + COALESCE(pg_get_viewdef(c.oid, TRUE), '') AS ddl
 FROM 
-	pg_catalog.pg_class AS c
+    pg_catalog.pg_class AS c
 INNER JOIN
-	pg_catalog.pg_namespace AS n
-		ON c.relnamespace = n.oid
+    pg_catalog.pg_namespace AS n
+    ON c.relnamespace = n.oid
 WHERE relkind = 'v'
 ;

--- a/src/AdminViews/v_get_obj_priv_by_user.sql
+++ b/src/AdminViews/v_get_obj_priv_by_user.sql
@@ -3,32 +3,33 @@ Purpose: View to get the table/views that a user has access to
 History:
 2013-10-29 jjschmit Created
 2016-05-24 chriz-bigdata addressed edge case for objects with names containing '.'
+2018-01-15 pvbouwel replaces tabs with spaces for nicer behavior in psql client
 **********************************************************************************************/
 CREATE OR REPLACE VIEW admin.v_get_obj_priv_by_user
 AS
 SELECT
-	* 
+    * 
 FROM 
-	(
-	SELECT 
-		schemaname
-		,objectname
-		,usename
-		,HAS_TABLE_PRIVILEGE(usrs.usename, fullobj, 'select') AS sel
-		,HAS_TABLE_PRIVILEGE(usrs.usename, fullobj, 'insert') AS ins
-		,HAS_TABLE_PRIVILEGE(usrs.usename, fullobj, 'update') AS upd
-		,HAS_TABLE_PRIVILEGE(usrs.usename, fullobj, 'delete') AS del
-		,HAS_TABLE_PRIVILEGE(usrs.usename, fullobj, 'references') AS ref
-	FROM
-		(
-		SELECT schemaname, 't' AS obj_type, tablename AS objectname, QUOTE_IDENT(schemaname) || '.' || QUOTE_IDENT(tablename) AS fullobj FROM pg_tables
-		WHERE schemaname not in ('pg_internal')
-		UNION
-		SELECT schemaname, 'v' AS obj_type, viewname AS objectname, QUOTE_IDENT(schemaname) || '.' || QUOTE_IDENT(viewname) AS fullobj FROM pg_views
-		WHERE schemaname not in ('pg_internal')
-		) AS objs
-		,(SELECT * FROM pg_user) AS usrs
-	ORDER BY fullobj
-	)
+    (
+    SELECT 
+        schemaname
+        ,objectname
+        ,usename
+        ,HAS_TABLE_PRIVILEGE(usrs.usename, fullobj, 'select') AS sel
+        ,HAS_TABLE_PRIVILEGE(usrs.usename, fullobj, 'insert') AS ins
+        ,HAS_TABLE_PRIVILEGE(usrs.usename, fullobj, 'update') AS upd
+        ,HAS_TABLE_PRIVILEGE(usrs.usename, fullobj, 'delete') AS del
+        ,HAS_TABLE_PRIVILEGE(usrs.usename, fullobj, 'references') AS ref
+    FROM
+        (
+        SELECT schemaname, 't' AS obj_type, tablename AS objectname, QUOTE_IDENT(schemaname) || '.' || QUOTE_IDENT(tablename) AS fullobj FROM pg_tables
+        WHERE schemaname not in ('pg_internal')
+        UNION
+        SELECT schemaname, 'v' AS obj_type, viewname AS objectname, QUOTE_IDENT(schemaname) || '.' || QUOTE_IDENT(viewname) AS fullobj FROM pg_views
+        WHERE schemaname not in ('pg_internal')
+        ) AS objs
+        ,(SELECT * FROM pg_user) AS usrs
+    ORDER BY fullobj
+    )
 WHERE (sel = true or ins = true or upd = true or del = true or ref = true)
 ;


### PR DESCRIPTION
Adapt views that generate statements to use `QUOTE_IDENT` for identifiers in order to give better support for identifiers that contain quotes.

For example:
```
tickit=# select ddl from admin.v_generate_tbl_ddl where tablename='po"i"nter';
                                                     ddl
--------------------------------------------------------------------------------------------------------------
 --DROP TABLE public."po""i""nter";
 CREATE TABLE IF NOT EXISTS public."po""i""nter"
 (
         "su""p""er" INTEGER   ENCODE lzo
 )
 DISTSTYLE EVEN
 ;
 ALTER TABLE public."po""i""nter" ADD FOREIGN KEY ("su""p""er") REFERENCES "my""schema"."ta""r""get"("i""d");
(8 rows)
```

The current views won't escape the double quotes and therefore generated DDL sometimes cannot be executed by Redshift.
The `QUOTE_IDENT` function will also quote identifiers that are keywords so if you have relations that use keywords as identifiers those will still work as well:
```
tickit=# select ddl from admin.v_generate_tbl_ddl where tablename='table';
                    ddl
-------------------------------------------
 --DROP TABLE public."table";
 CREATE TABLE IF NOT EXISTS public."table"
 (
         id INTEGER   ENCODE lzo
 )
 DISTSTYLE EVEN
 ;
```
The posgresql functions like `textin (regprocedureout (pproc.oid::regprocedure))` will generate  representations for identifiers which can be used without conversion (for this particular instance you mustn't use `QUOTE_IDENT` because it will think the whole input is an identifier but only the function name should be treated as an identifier).
```
tickit=# select ddl from admin.v_find_dropuser_objs where objname like '%"%ow%';
                           ddl
----------------------------------------------------------
 alter function public."f_""s""low"(anyelement) owner to
(1 row)
```

If an identifier does not need double quotes then `QUOTE_IDENT` omits them but the resulting DDL will still work without a problem.