### PR TITLE
Add v_generate_database_ddl.sql in the same spirit as other views

### DIFF
--- a/src/AdminViews/README.md
+++ b/src/AdminViews/README.md
@@ -12,6 +12,7 @@ All views assume you have a schema called admin.
 | v\_constraint\_dependency.sql |   View to get the the foreign key constraints between tables | 
 | v\_extended\_table\_info.sql| View to get extended table information for permanent database tables.
 | v\_generate\_cancel\_query.sql | View to get cancel query |
+| v\_generate\_database\_ddl.sql | View to get the DDL for a database |
 | v\_generate\_group\_ddl.sql |   View to get the DDL for a group. | 
 | v\_generate\_schema\_ddl.sql |   View to get the DDL for schemas. | 
 | v\_generate\_tbl\_ddl.sql | View to get the DDL for a table.  This will contain the distkey, sortkey, constraints |

--- a/src/AdminViews/v_generate_database_ddl.sql
+++ b/src/AdminViews/v_generate_database_ddl.sql
@@ -1,0 +1,16 @@
+--DROP VIEW admin.v_generate_database_ddl;
+/**********************************************************************************************
+Purpose: View to get the DDL for a database 
+History:
+2018-01-20 pvbouwel Create the view
+**********************************************************************************************/
+CREATE OR REPLACE VIEW admin.v_generate_database_ddl
+AS
+SELECT
+  datname as datname,
+  'CREATE DATABASE ' + QUOTE_IDENT(datname) + ' WITH CONNECTION LIMIT ' + datconnlimit + ';' AS ddl
+FROM pg_catalog.pg_database_info
+WHERE datdba >= 100
+ORDER BY datname
+;
+


### PR DESCRIPTION
To get DDL for user defined databases.

Example output:
```
tickit=# select * from admin.v_generate_database_ddl ;
 datname |                             ddl
---------+-------------------------------------------------------------
 my"data | CREATE DATABASE "my""data" WITH CONNECTION LIMIT UNLIMITED;
 ssb     | CREATE DATABASE ssb WITH CONNECTION LIMIT UNLIMITED;
 ssb2    | CREATE DATABASE ssb2 WITH CONNECTION LIMIT UNLIMITED;
 test    | CREATE DATABASE test WITH CONNECTION LIMIT 20;
 tickit  | CREATE DATABASE tickit WITH CONNECTION LIMIT UNLIMITED;
(5 rows)
```

Similar to other views it copies attributes (for database currently create DDL only has connection limit) except for ownership. 