### PR TITLE
Add TCP Keepalives for column encoding tool

### DIFF
--- a/src/ColumnEncodingUtility/analyze-schema-compression.py
+++ b/src/ColumnEncodingUtility/analyze-schema-compression.py
@@ -42,6 +42,7 @@ import os
 import re
 import sys
 import traceback
+import socket
 from multiprocessing import Pool
 
 import boto3
@@ -177,6 +178,10 @@ def get_pg_conn():
         try:
             conn = pg8000.connect(user=db_user, host=db_host, port=db_port, database=db, password=db_pwd,
                                   ssl=ssl, timeout=None)
+            # Enable keepalives manually untill pg8000 supports it
+            # For future reference: https://github.com/mfenniak/pg8000/issues/149
+            # TCP keepalives still need to be configured appropriately on OS level as well
+            conn._usock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
         except Exception as e:
             print(e)
             print('Unable to connect to Cluster Endpoint')


### PR DESCRIPTION
This is a pull request for the column encoding tool.  This would help with the issue in  https://github.com/awslabs/amazon-redshift-utils/issues/224 

In the ideal case pg8000 will support TCP keepalives however since for this tool it's always beneficial to have keepalives on we can just manually do it by operating on the socket. 

```
[ec2-user@ip-172-31-7-182 ~]$ netstat -top | grep "`ps -ef | grep analyze | grep -v grep | awk '{ print $2}'`"
(Not all processes could be identified, non-owned process info
 will not be shown, you would have to be root to see it all.)
tcp        0      0 ip-XXX-XX-XX-XXX.eu-we:43566 ip-XXX-XX-XX-XXX.eu-we:5439 ESTABLISHED 3021/python         keepalive (5.75/0/0)
```