### PR TITLE
Fixed typo in config_constants and Redshift automation config call

### DIFF
--- a/src/RedshiftAutomation/lambda_function.py
+++ b/src/RedshiftAutomation/lambda_function.py
@@ -49,7 +49,7 @@ def event_handler(event, context):
     if event is not None and 'ConfigLocation' in event:
         config_location = event['ConfigLocation']
 
-    config = common.get_config(config_location)
+    config = common.get_config(config_location, current_region)
 
     if config_constants.DEBUG in config and config[config_constants.DEBUG]:
         debug = True

--- a/src/config_constants.py
+++ b/src/config_constants.py
@@ -55,7 +55,7 @@ config_aliases = {
     "table_name": ["analyzeTable"],
     "schema_name": ["analyzeSchema"],
     "target_schema": ["targetSchema"],
-    "cluster_name": ["ClusterName, clusterName"],
+    "cluster_name": ["ClusterName", "clusterName"],
     "do_analyze": ["doAnalyze", "analyze_flag", "analyze-flag"],
     "do_vacuum": ["doVacuum", "vacuum_flag", 'vacuum-flag'],
     "do_execute": ["do-execute"],


### PR DESCRIPTION
Fixed one typo in list in config_constants and another missing region variable from config function call in Redshift Automation project