### PR TITLE
Fix malformed SQL if no SORTKEY

### DIFF
--- a/src/ColumnEncodingUtility/analyze-schema-compression.py
+++ b/src/ColumnEncodingUtility/analyze-schema-compression.py
@@ -762,6 +762,8 @@ def analyze(table_info):
                                                                             table_name)
                 if len(table_sortkeys) > 0:
                     insert = "%s order by %s;" % (insert, ",".join(table_sortkeys))
+                else:
+                    insert = "%s;" % (insert)
 
                 statements.extend([insert])
 


### PR DESCRIPTION
If table had no SORTKEY the Column Encoding Utility was returning
bogus SQL (it was missing a semicolon(;) between statements).