### PR TITLE
Redshift Utilities for ETL development

### DIFF
--- a/src/RedshiftETLTools/bin/common.py
+++ b/src/RedshiftETLTools/bin/common.py
@@ -1,0 +1,162 @@
+import psycopg2
+import os
+import sys
+import json
+import base64
+import boto3
+import logging
+import datetime
+
+global nowString
+nowString = "{:%Y-%m-%d_%H-%M-%S}".format(datetime.datetime.now())
+
+def setupLogging(jobName, path):
+    config = getConfig(path)
+    logFileName = config['defLogConfigs']['logdirectory'] + jobName + "." + nowString + ".log"
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger(__name__)
+
+    handler = logging.FileHandler(logFileName)
+    handler.setLevel(logging.INFO)
+
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    return logger
+
+def getConfig(path):
+
+    if path.startswith("s3://"):
+        # download the configuration from s3
+        s3Info = tokeniseS3Path(path)
+
+        bucket = s3Client.get_bucket(s3Info[0])
+        key = bucket.get_key(s3Info[1])
+
+        configContents = key.get_contents_as_string()
+        config = json.loads(configContents)
+    else:
+        with open(path) as f:
+            config = json.load(f)
+    return config
+
+def returnConn(host, port, db, usr, pwd):
+    connstring = '''dbname=%s user=%s password=%s
+           host=%s port=%s''' % (db, usr, pwd, host, port)
+    pcon = psycopg2.connect(connstring)
+    pcon.autocommit = True
+    return pcon
+
+def rsConn(path):
+    config = getConfig(path)
+    srcConfig = config['redshiftCreds']
+    srcHost = srcConfig['clusterEndpoint']
+    srcPort = srcConfig['clusterPort']
+    srcDB = srcConfig['db']
+    srcUser = srcConfig['connectUser']
+    srcPassword = srcConfig['connectPwd']
+    return (returnConn(srcHost, srcPort, srcDB, srcUser, srcPassword))
+
+def getDefaultParms(path):
+    config = getConfig(path)
+    defaultParms = config['defLoadCopyConfigs']
+    addquotes = 'addquotes' if defaultParms['addquotes'] else ''
+    gzip = 'gzip' if defaultParms['gzip'] else ''
+    escape = 'escape' if defaultParms['escape'] else ''
+    manifest = 'manifest' if defaultParms['manifest'] else ''
+    allowoverwrite = 'allowoverwrite' if defaultParms['allowoverwrite'] else ''
+    delimiter = defaultParms['delimiter']
+    return  """%s %s %s %s %s delimiter '%s'""" %(addquotes, gzip, escape, manifest, allowoverwrite, delimiter)
+
+def getDataDownloadPath(queryName, path):
+    config = getConfig(path)
+    return "%s/%s/%s/" % (config['s3Creds']['path'].rstrip("/"), queryName, nowString)
+
+def getS3creds(path):
+    config = getConfig(path)
+    if config['s3Creds']['awsIamRole'] != "":
+        accessRole = config['s3Creds']['awsIamRole']
+        s3AccessCredentials = "aws_iam_role=%s" % accessRole
+    else:
+        awsAccessKeyId = config['s3Creds']['awsAccessKeyId']
+        awsSecretAccessKey = config['s3Creds']['awsSecretAccessKey']
+        s3AccessCredentials = "aws_access_key_id=%s;aws_secret_access_key=%s" % (awsAccessKeyId, awsSecretAccessKey)
+    return s3AccessCredentials
+
+def getQueryInfo(filePath):
+    if os.path.basename(filePath).rsplit('.', 1)[1] == 'json':
+        with open(filePath) as sqlFile:
+            queryConfig = json.load(sqlFile)
+            queryName = queryConfig['queryDetails']['queryName']
+            sqlText = queryConfig['queryDetails']['query']
+    else:
+        queryName = os.path.basename(filePath).rsplit('.', 1)[0]
+        with open(filePath) as f: sqlText = f.read()
+    return queryName, sqlText
+
+def execQuery(conn, query, logger):
+    try:
+        cur=conn.cursor()
+        cur.execute(query)
+        cur.close()
+        return True
+
+    except psycopg2.Error, e:
+        try:
+           print "Redshift Error [%d]: %s" % (e.args[0], e.args[1])
+           logger.error("Redshift Error [%d]: %s" % (e.args[0], e.args[1]))
+           return False
+        except IndexError:
+          print "Redshift Error: %s" % str(e)
+          logger.error("Redshift Error: %s" % str(e))
+          return False
+        except TypeError, e:
+          print(e)
+          logger.error(e)
+          return False
+        except ValueError, e:
+          print(e)
+          logger.error(e)
+          return False
+    finally:
+        cur.close()
+
+def execSelect(conn, query, logger):
+    try:
+        cur=conn.cursor()
+        cur.execute(query)
+        results = cur.fetchall()
+        cur.close()
+        return results
+
+    except psycopg2.Error, e:
+        try:
+           print "Redshift Error [%d]: %s" % (e.args[0], e.args[1])
+           logger.error("Redshift Error [%d]: %s" % (e.args[0], e.args[1]))
+           return False
+        except IndexError:
+          print "Redshift Error: %s" % str(e)
+          logger.error("Redshift Error: %s" % str(e))
+          return False
+        except TypeError, e:
+          print(e)
+          logger.error(e)
+          return False
+        except ValueError, e:
+          print(e)
+          logger.error(e)
+          return False
+    finally:
+        cur.close()
+
+def returnRowCount(results):
+  for i in results:
+    return i[0]
+
+def checkTableExists(conn, schemaName, tableName):
+  sqlText = "select count(*) From pg_catalog.pg_tables where schemaname='" + schemaName + "' and tablename='"+ tableName +"'"
+  results = execSelect(conn, sqlText)
+  if returnRowCount(results)> 0:
+    return True
+  else:
+    return False

--- a/src/RedshiftETLTools/bin/common_rs_copy.py
+++ b/src/RedshiftETLTools/bin/common_rs_copy.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+import sys
+import common
+import argparse
+
+s3Client = None
+nowString = None
+#config = None
+region = None
+bucket = None
+key = None
+
+def usage():
+    print "Redshift Copy Utility"
+    print "Exports data from a source Redshift database to S3."
+    print ""
+    print "Usage: This utility needs two arguments the path of configs and the sql file."
+    print "python common_rs_copy.py <configuration> <sql_file>"
+    print "    <configuration> Local Path to configs file in configs directory"
+    print "    <target table> you want to load the data into."
+    print "    <sql_file> Contains the select statement that needs to be used to download data. Can be in json or plain sql file. examples in sql folder."
+    print "Additionally you can specify:"
+    print " the copy parameter with a -u/--copyParams parameter. These parms are delimiter, removequotes, escape etc. passed as a string."
+    print "Usage example with optional parameters"
+    print "/git/amazon-redshift-utils/RedshiftETLTools/bin/common_rs_copy.py /git/amazon-redshift-utils/RedshiftETLTools/config/connect_configs public.events   s3://analytics-s3.company.com/events/2018-02-08_15-33-21/ removequotes  escape  delimiter ','"
+    sys.exit(-1)
+
+
+def prepCopy(tgtConn, tgtTableName, dataPath, s3AccessCredentials, copyParams):
+
+    copyStmt = """copy %s
+                 from '%s'
+                 credentials '%s'
+                 maxerror 10000
+                 %s"""
+
+    query = copyStmt % (tgtTableName, dataPath, s3AccessCredentials, copyParams)
+
+    logger.info("Importing into %s data from %s" % (tgtTableName, dataPath))
+    logger.info("Copy Query: %s" % (query))
+
+    if common.execQuery(tgtConn, query,logger):
+        logger.info("Loading %s Successful." %(tgtTableName))
+
+def rsCopy(configFilePath,tgtTableName,dataPath, copyParams = None):
+
+    # Logging
+    global logger
+    logger = common.setupLogging(tgtTableName, configFilePath)
+
+    #get S3 connection credentials from config path
+    s3AccessCredentials = common.getS3creds(configFilePath)
+
+    if not copyParams:
+        copyParams = common.getDefaultParms(configFilePath)
+        copyParams = copyParams.replace("addquotes", "removequotes")
+        copyParams = copyParams.replace("allowoverwrite", "")
+
+    if not dataPath.startswith("s3://"):
+        print "s3Staging.path must be a path to S3"
+        sys.exit(-1)
+
+    logger.info("Loading into table %s" %(tgtTableName))
+    tgtConn = common.rsConn(configFilePath)
+    prepCopy(tgtConn, tgtTableName, dataPath, s3AccessCredentials, copyParams)
+
+    tgtConn.close()
+
+def main(args):
+    if len(args) < 4:
+        usage()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("configFilePath", help="Location for configuration file.")
+    parser.add_argument("tgtTableName", help="Table to load to. Provide in the form schemaname.tablename")
+    parser.add_argument("srcDataPath", help="S3 location to source the data.")
+    parser.add_argument("--copyParams", "-u", help="User copy parameters to override settings from configuration file path.  -u 'delimiter '^' addquotes'")
+    args = parser.parse_args()
+    rsCopy(args.configFilePath,args.tgtTableName,args.srcDataPath,args.copyParams)
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/src/RedshiftETLTools/bin/common_rs_execquery.py
+++ b/src/RedshiftETLTools/bin/common_rs_execquery.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+import sys
+import common
+import argparse
+
+def usage():
+    print "Redshift Execute Query Utility"
+    print "Executes a query in Redshift."
+    print ""
+    print "Usage: This utility needs one argument the path of the sql file."
+    print "python common_rs_execquery.py <configuration> <sql_file_path>"
+    print "    <configuration> Local Path to configs file in configs directory"
+    print "    <sql_file> Contains the select statement that needs to be used to download data.  Can be in json or plain sql file. examples in sql folder."
+    print "python  /git/amazon-redshift-utils/RedshiftETLTools/bin/common_rs_execquery.py /git/amazon-redshift-utils/RedshiftETLTools/config/connect_configs /git/amazon-redshift-utils/RedshiftETLTools/sql/events_hr_ul.sql"
+    sys.exit(-1)
+
+def rsExecQuery(configFilePath,sqlFilePath):
+    # read SQL file
+    queryName, query = common.getQueryInfo(sqlFilePath)
+    # Logging
+    global logger
+    logger = common.setupLogging(queryName, configFilePath)
+
+    logger.info("Executing query %s" %(query))
+    dbConn = common.rsConn(configFilePath)
+    if common.execQuery(dbConn, query,logger):
+        logger.info("Query Successfully Executed.")
+    dbConn.close()
+
+def main(args):
+    if len(args) < 3:
+        usage()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("configFilePath", help="Location for configuration file.")
+    parser.add_argument("sqlFilePath", help="Location for SQL file.")
+    args = parser.parse_args()
+    rsExecQuery(args.configFilePath,args.sqlFilePath)
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/src/RedshiftETLTools/bin/common_rs_unload.py
+++ b/src/RedshiftETLTools/bin/common_rs_unload.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+import sys
+import common
+import argparse
+
+s3Client = None
+nowString = None
+#config = None
+region = None
+bucket = None
+key = None
+
+def usage():
+    print "Redshift Unload Utility"
+    print "Exports data from a source Redshift database to S3."
+    print ""
+    print "Usage: This utility needs two arguments the path of configs and the sql file."
+    print "python common_rs_unload.py <configuration> <sql_file>"
+    print "    <configuration> Local Path to configs file in configs directory"
+    print "    <sql_file> Contains the select statement that needs to be used to download data."
+    print "Additionally you can specify:"
+    print " the S3 Data Stage location with a -l/--dataDownloadPath parameter."
+    print " the unload parameter with a -u/--unloadParms parameter. These parms are delimiter, addquotes, escape etc. passed as a string."
+    print "Usage example with optional parameters"
+    print "python  /git/amazon-redshift-utils/RedshiftETLTools/bin/common_rs_unload.py /git/amazon-redshift-utils/RedshiftETLTools/config/connect_configs /git/amazon-redshift-utils/RedshiftETLTools/sql/sov_aggregates.sql -l s3://analytics.riffsy.com/tp_events/2018-02-07_13/"
+    sys.exit(-1)
+
+
+def prepUnload(conn, sqlText, dataDownloadPath, s3AccessCredentials, unloadParams):
+
+    unloadStmt = """unload ('%s')
+                 to '%s' credentials
+                 '%s'
+                 %s"""
+
+    query = unloadStmt % (sqlText, dataDownloadPath, s3AccessCredentials, unloadParams)
+    logger.info("Exporting %s data to %s" % (sqlText, dataDownloadPath))
+    logger.info("Unload Query: %s" % (query))
+
+    if common.execQuery(conn, query,logger):
+        logger.info("Export Successful.")
+
+def rsUnload(configFilePath,sqlFilePath,dataDownloadPath = None,unloadParams = None):
+    # read SQL file
+    queryName, sqlText = common.getQueryInfo(sqlFilePath)
+    # Logging
+    global logger
+    logger = common.setupLogging(queryName, configFilePath)
+
+    #get S3 connection credentials from config path
+    s3AccessCredentials = common.getS3creds(configFilePath)
+
+    if not unloadParams:
+        unloadParams = common.getDefaultParms(configFilePath)
+
+    # Unload Location Parms
+    if not dataDownloadPath:
+        dataDownloadPath = common.getDataDownloadPath(queryName,configFilePath)
+
+    if not dataDownloadPath.startswith("s3://"):
+        logger.info("s3Staging.path must be a path to S3")
+        sys.exit(-1)
+
+    logger.info("Exporting from Source...")
+    srcConn = common.rsConn(configFilePath)
+    prepUnload(srcConn, sqlText, dataDownloadPath, s3AccessCredentials, unloadParams)
+
+    srcConn.close()
+
+def main(args):
+    if len(args) < 3:
+        usage()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("configFilePath", help="Location for configuration file.")
+    parser.add_argument("sqlFilePath", help="Location for SQL file.")
+    parser.add_argument("--dataDownloadPath", "-l", help="S3 location to unload data. if not provided takes the info from configFilePath.")
+    parser.add_argument("--unloadParams", "-u", help="Unload parameters to override settings from configuration file path.  -u 'delimiter '^' addquotes'")
+    args = parser.parse_args()
+    rsUnload(args.configFilePath,args.sqlFilePath,args.dataDownloadPath,args.unloadParams)
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/src/RedshiftETLTools/config/connect_configs
+++ b/src/RedshiftETLTools/config/connect_configs
@@ -1,0 +1,28 @@
+{
+	"redshiftCreds": {
+		"clusterEndpoint": "clustername.aseczpony.us-west-2.redshift.amazonaws.com",
+		"clusterPort": 5439,
+		"connectPwd": "super_secret",
+		"connectUser": "etl_user",
+		"db": "dev",
+		"schemaName": "public"
+	},
+	"s3Creds": {
+	  "awsIamRole": "",
+		"awsAccessKeyId": "AKIAXXXXXXXXX",
+		"awsSecretAccessKey": "ASDFEDGHJKLIOPTjelemosenSDFEAD",
+		"path": "s3://analytics-s3.company.com/",
+		"region": "us-west-1"
+	},
+	"defLoadCopyConfigs": {
+		"addquotes": "True",
+		"gzip": "",
+		"escape": "True",
+		"manifest": "",
+		"allowoverwrite": "True",
+		"delimiter": ","
+	},
+	"defLogConfigs": {
+		"logdirectory": "~/git/amazon-redshift-utils/RedshiftETLTools/logs/"
+	}
+}

--- a/src/RedshiftETLTools/sql/events_hr_ul.json
+++ b/src/RedshiftETLTools/sql/events_hr_ul.json
@@ -1,0 +1,6 @@
+{
+"queryDetails": {
+"queryName": "events_hr",
+"query": "select * from events where timestamp >= (select date_trunc(''hour'',max(timestamp)) from events)"
+ }
+}

--- a/src/RedshiftETLTools/sql/events_hr_ul.sql
+++ b/src/RedshiftETLTools/sql/events_hr_ul.sql
@@ -1,0 +1,1 @@
+select * from events where timestamp >= (select date_trunc(''hour'',max(timestamp)) from events)


### PR DESCRIPTION
Having a utility that takes in command line parameters for unload, copy and execute query would greatly reduce the time for ETL development. The set of utilities would use standard logging practice, notification and Error Handling. Scheduling them on cron, aws scheduler, airflow should then be very easy to do.

Redshift Copy Utility
Exports data from a source Redshift database to S3.

   Usage: This utility needs two arguments the path of configs and the sql file. 
   python common_rs_copy.py <configuration> <sql_file> 
       <configuration> Local Path to configs file in configs directory 
       <target table> you want to load the data into. 
       <sql_file> Contains the select statement that needs to be used to download data. Can be in json or plain sql file. examples in sql folder. 
   Additionally you can specify: 
    the copy parameter with a -u/--copyParams parameter. These parms are delimiter, removequotes, escape etc. passed as a string. 
   Usage example with optional parameters 
   /git/amazon-redshift-utils/RedshiftETLTools/bin/common_rs_copy.py /git/amazon-redshift-utils/RedshiftETLTools/config/connect_configs public.events   s3://analytics-s3.company.com/events/2018-02-08_15-33-21/ removequotes  escape  delimiter ',' 
Redshift Execute Query Utility
Executes a query in Redshift.

   Usage: This utility needs one argument the path of the sql file. 
   python common_rs_execquery.py <configuration> <sql_file_path> 
       <configuration> Local Path to configs file in configs directory 
       <sql_file> Contains the select statement that needs to be used to download data.  Can be in json or plain sql file. examples in sql folder. 
   python  /git/amazon-redshift-utils/RedshiftETLTools/bin/common_rs_execquery.py /git/amazon-redshift-utils/RedshiftETLTools/config/connect_configs /git/amazon-redshift-utils/RedshiftETLTools/sql/events_hr_ul.sql 
Redshift Unload Utility
Exports data from a source Redshift database to S3.

   Usage: This utility needs two arguments the path of configs and the sql file. 
   python common_rs_unload.py <configuration> <sql_file> 
       <configuration> Local Path to configs file in configs directory 
       <sql_file> Contains the select statement that needs to be used to download data. 
   Additionally you can specify: 
    the S3 Data Stage location with a -l/--dataDownloadPath parameter. 
    the unload parameter with a -u/--unloadParms parameter. These parms are delimiter, addquotes, escape etc. passed as a string. 
   Usage example with optional parameters 
   python  /git/amazon-redshift-utils/RedshiftETLTools/bin/common_rs_unload.py /git/amazon-redshift-utils/RedshiftETLTools/config/connect_configs /git/amazon-redshift-utils/RedshiftETLTools/sql/sov_aggregates.sql -l s3://analytics.riffsy.com/tp_events/2018-02-07_13/ 
sys.exit(-1)