### PR TITLE
True and False should be Uppercase

### DIFF
--- a/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
+++ b/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
@@ -77,7 +77,7 @@ def usage(with_message=None):
     print('           --db-host            - The Cluster endpoint')
     print('           --db-port            - The Cluster endpoint port : Default = 5439')
     print('           --db-conn-opts       - Additional connection options. "name1=opt1[ name2=opt2].."')
-    print('           --require-ssl        - Does the connection require SSL? (true | false)')
+    print('           --require-ssl        - Does the connection require SSL? (True | False)')
     print('           --schema-name        - The Schema to be Analyzed or Vacuumed : Default = public')
     print('           --table-name         - A specific table to be Analyzed or Vacuumed, if --analyze-schema is not desired')
     print('           --blacklisted-tables - The tables we do not want to Vacuum')


### PR DESCRIPTION
If we're going to branch on `True` and `False`, let's keep it consistent in the usage documentation.