### PR TITLE
Analyze cols now uses octet_length instead of len.

### DIFF
--- a/src/ColumnEncodingUtility/analyze-schema-compression.py
+++ b/src/ColumnEncodingUtility/analyze-schema-compression.py
@@ -554,7 +554,7 @@ def analyze(table_info):
                 if analyze_col_width and "character varying" in col_type:
                     curr_col_length = int(re.search(r'\d+', col_type).group())
                     if curr_col_length > 255:
-                        col_len_statement = 'select /* computing max column length */ max(len("%s")) from %s."%s"' % (
+                        col_len_statement = 'select /* computing max column length */ max(octet_length("%s")) from %s."%s"' % (
                             descr[col][0], schema_name, table_name)
                         try:
                             if debug:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Analyze cols now uses octet_length instead of len for varchars

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
