### PR TITLE
Skip excessive amount of rows by keeping only table comment objects

### DIFF
--- a/src/ColumnEncodingUtility/analyze-schema-compression.py
+++ b/src/ColumnEncodingUtility/analyze-schema-compression.py
@@ -982,7 +982,7 @@ def run():
         statement = '''select pgn.nspname::text as schema, trim(a.name) as table, b.mbytes, a.rows, decode(pgc.reldiststyle,0,'EVEN',1,'KEY',8,'ALL') dist_style, TRIM(pgu.usename) "owner", pgd.description
 from (select db_id, id, name, sum(rows) as rows from stv_tbl_perm a group by db_id, id, name) as a
 join pg_class as pgc on pgc.oid = a.id
-left outer join pg_description pgd ON pgd.objoid = pgc.oid
+left outer join pg_description pgd ON pgd.objoid = pgc.oid and pgd.objsubid = 0
 join pg_namespace as pgn on pgn.oid = pgc.relnamespace
 join pg_user pgu on pgu.usesysid = pgc.relowner
 join (select tbl, count(*) as mbytes
@@ -996,7 +996,7 @@ and pgn.nspname::text ~ '%s' and pgc.relname in (%s)
         statement = '''select pgn.nspname::text as schema, trim(a.name) as table, b.mbytes, a.rows, decode(pgc.reldiststyle,0,'EVEN',1,'KEY',8,'ALL') dist_style, TRIM(pgu.usename) "owner", pgd.description
 from (select db_id, id, name, sum(rows) as rows from stv_tbl_perm a group by db_id, id, name) as a
 join pg_class as pgc on pgc.oid = a.id
-left outer join pg_description pgd ON pgd.objoid = pgc.oid
+left outer join pg_description pgd ON pgd.objoid = pgc.oid and pgd.objsubid = 0
 join pg_namespace as pgn on pgn.oid = pgc.relnamespace
 join pg_user pgu on pgu.usesysid = pgc.relowner 
 join (select tbl, count(*) as mbytes


### PR DESCRIPTION
*Description of changes:*

When table columns have comments, `analyze-schema-compression.py` ends up duplicating the same table for analysis, as many times as there are columns with comments. The change included selects only table comments objects from `pg_description`, to keep the set of joined rows to correct amount.

Additionally, one could use set for `tables_names` to prevent duplicates:

https://github.com/awslabs/amazon-redshift-utils/blob/master/src/ColumnEncodingUtility/analyze-schema-compression.py#L1018

The original problem should be reproducible by adding comments to table columns and running the utility, which should result in multiple occurrences of the table selected for analysis.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
