### PR TITLE
Removed erroneous help text

### DIFF
--- a/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
+++ b/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
@@ -78,7 +78,7 @@ def usage(with_message=None):
     print('           --db-port            - The Cluster endpoint port : Default = 5439')
     print('           --db-conn-opts       - Additional connection options. "name1=opt1[ name2=opt2].."')
     print('           --require-ssl        - Does the connection require SSL? (True | False)')
-    print('           --schema-name        - The Schema to be Analyzed or Vacuumed : Default = public')
+    print('           --schema-name        - The Schema to be Analyzed or Vacuumed')
     print('           --table-name         - A specific table to be Analyzed or Vacuumed, if --analyze-schema is not desired')
     print('           --blacklisted-tables - The tables we do not want to Vacuum')
     print('           --output-file        - The full path to the output file to be generated')


### PR DESCRIPTION
The default schema isn't "public" but rather "schema_name". Given that this is controlled in another file entirely, we probably shouldn't tie an assumption on what the default will be in the argument help text here.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
