### PR TITLE
Allow importing table via flag provided we give a schema

### DIFF
--- a/src/UnloadCopyUtility/global_config_parameters.json
+++ b/src/UnloadCopyUtility/global_config_parameters.json
@@ -68,5 +68,10 @@
     "description": "The path to the config file used for this execution.  Should only be used as CLI parameter.",
     "value": "None",
     "possibleValues": "/any/valid/system/path|s3://any/valid/s3/path"
+  },
+  "tableName": {
+    "description": "The table that is being copied from source to destination. Should be same name.",
+    "value": "None",
+    "possibleValues": "table_name"
   }
 }

--- a/src/UnloadCopyUtility/redshift_unload_copy.py
+++ b/src/UnloadCopyUtility/redshift_unload_copy.py
@@ -24,7 +24,7 @@ import sys
 import logging
 from global_config import GlobalConfigParametersReader, config_parameters
 from util.s3_utils import S3Helper, S3Details
-from util.resources import ResourceFactory
+from util.resources import ResourceFactory, TableResource
 from util.tasks import TaskManager, FailIfResourceDoesNotExistsTask, CreateIfTargetDoesNotExistTask, \
     FailIfResourceClusterDoesNotExistsTask, UnloadDataToS3Task, CopyDataFromS3Task, CleanupS3StagingAreaTask, \
     NoOperationTask
@@ -78,6 +78,10 @@ class UnloadCopyTool:
         source = ResourceFactory.get_source_resource_from_config_helper(self.config_helper, self.region)
 
         destination = ResourceFactory.get_target_resource_from_config_helper(self.config_helper, self.region)
+
+        if global_config_values['tableName']:
+            source = TableResource(source.get_cluster(), source.get_schema(), global_config_values['tableName'])
+            destination = TableResource(destination.get_cluster(), destination.get_schema(), global_config_values['tableName'])
 
         self.task_manager = TaskManager()
         self.barrier_after_all_cluster_pre_tests = NoOperationTask()

--- a/src/UnloadCopyUtility/util/s3_utils.py
+++ b/src/UnloadCopyUtility/util/s3_utils.py
@@ -124,9 +124,10 @@ class S3Details:
             if 'path' in s3_staging_conf:
                 # datetime alias for operations
                 self.nowString = "{:%Y-%m-%d_%H:%M:%S}".format(datetime.datetime.now())
-                self.dataStagingRoot = "{s3_stage_path}/{timestamp}/".format(
+                self.dataStagingRoot = "{s3_stage_path}/{timestamp}-{table_name}/".format(
                     s3_stage_path=s3_staging_conf['path'].rstrip("/"),
-                    timestamp=self.nowString
+                    timestamp=self.nowString,
+                    table_name=source_table.get_table()
                 )
                 self.dataStagingPath = "{root}{db_name}.{schema_name}.{table_name}".format(
                     root=self.dataStagingRoot,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This provides a new global config option `tableName` which allows you to import a specific table from your redshift cluster without needing to specify it in your config.json file. So you could use this to run a query to gather your tables and then them import them in parallel (using xargs or parallel or the like).

Additionally, the s3 prefix is broken up by table name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
