### PR TITLE
Ensure ignore_errors passed to run_command in all scenarios

### DIFF
--- a/src/AnalyzeVacuumUtility/lib/analyze_vacuum.py
+++ b/src/AnalyzeVacuumUtility/lib/analyze_vacuum.py
@@ -291,7 +291,7 @@ def run_vacuum(conn,
         statements.append(vs[0])
         statements.append("analyze %s.\"%s\"" % (schema_name, vs[1]))
 
-    if not run_commands(conn, statements, cw=cw, cluster_name=cluster_name):
+    if not run_commands(conn, statements, cw=cw, cluster_name=cluster_name, suppress_errors=ignore_errors):
         if not ignore_errors:
             if debug:
                 print("Error running statements: %s" % (str(statements),))
@@ -339,7 +339,7 @@ def run_vacuum(conn,
             statements.append(vs[0])
             statements.append("analyze %s.\"%s\"" % (vs[2], vs[1]))
 
-        if not run_commands(conn, statements, cw=cw, cluster_name=cluster_name):
+        if not run_commands(conn, statements, cw=cw, cluster_name=cluster_name, suppress_errors=ignore_errors):
             if not ignore_errors:
                 if debug:
                     print("Error running statements: %s" % (str(statements),))


### PR DESCRIPTION
Some scenarios, such as when vacuum fails due to the slot count limit being reached, will fail even when ignore-errors is set to TRUE. Added ignore-errors into run_command where it was not being used.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
