### PR TITLE
Update v_find_dropuser_objs.sql

### DIFF
--- a/src/AdminViews/v_find_dropuser_objs.sql
+++ b/src/AdminViews/v_find_dropuser_objs.sql
@@ -18,6 +18,8 @@ History:
 2017-04-06 adedotua improvements
 2018-01-06 adedotua added ddl column to generate ddl for transferring object ownership
 2018-01-15 pvbouwel Add QUOTE_IDENT for identifiers
+2018-05-29 adedotua added filter to skip temp tables
+
 **********************************************************************************************/
 
 CREATE OR REPLACE VIEW admin.v_find_dropuser_objs as 
@@ -72,6 +74,7 @@ FROM pg_class pgc,
      pg_namespace nc
 WHERE pgc.relnamespace = nc.oid
 AND   pgc.relkind IN ('r','v')
-AND   pgu.usesysid = pgc.relowner) OWNER ("objtype","objowner","userid","schemaname","objname","ddl") 
+AND   pgu.usesysid = pgc.relowner
+AND   nc.nspname NOT ILIKE 'pg\_temp\_%') OWNER ("objtype","objowner","userid","schemaname","objname","ddl") 
 WHERE owner.userid > 1;
 


### PR DESCRIPTION
updated view to filter out temp tables. temp table ownership cannot be changed.
 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
