### PR TITLE
ColumnEncodingUtility README.md requirements.txt relative path fixed

### DIFF
--- a/src/ColumnEncodingUtility/README.md
+++ b/src/ColumnEncodingUtility/README.md
@@ -1,21 +1,21 @@
 # Amazon Redshift Column Encoding Utility
 
-In order to get the best performance from your Redshift Database, you must ensure 
-that database tables have the correct Column Encoding applied (see [http://docs.aws.amazon.com/redshift/latest/dg/t\_Compressing\_data\_on\_disk.html](http://docs.aws.amazon.com/redshift/latest/dg/t_Compressing_data_on_disk.html)). 
-Column Encoding specifies which algorithm is used to compress data within a column, 
-and is chosen on the basis of the datatype, the unique number of discrete values 
+In order to get the best performance from your Redshift Database, you must ensure
+that database tables have the correct Column Encoding applied (see [http://docs.aws.amazon.com/redshift/latest/dg/t\_Compressing\_data\_on\_disk.html](http://docs.aws.amazon.com/redshift/latest/dg/t_Compressing_data_on_disk.html)).
+Column Encoding specifies which algorithm is used to compress data within a column,
+and is chosen on the basis of the datatype, the unique number of discrete values
 in the column, and so on. When the [COPY command](http://docs.aws.amazon.com/redshift/latest/dg/r_COPY.html)
-is used to load data into a table, column encoding will be analyzed and applied by default. 
-Other tables may be loaded via Extract/Load/Transform/Load (ELT) processes, and 
+is used to load data into a table, column encoding will be analyzed and applied by default.
+Other tables may be loaded via Extract/Load/Transform/Load (ELT) processes, and
 these tables may require having the column encoding updated at some point.
 
-The Redshift Column Encoding Utility gives you the ability to apply optimal Column 
-Encoding to an established Schema with data already loaded. When run, it will analyze 
-an entire schema or individual tables. The [ANALYZE COMPRESSION](http://docs.aws.amazon.com/redshift/latest/dg/r_ANALYZE_COMPRESSION.html) 
-command is used to determine if any of the columns in the table require updating, 
+The Redshift Column Encoding Utility gives you the ability to apply optimal Column
+Encoding to an established Schema with data already loaded. When run, it will analyze
+an entire schema or individual tables. The [ANALYZE COMPRESSION](http://docs.aws.amazon.com/redshift/latest/dg/r_ANALYZE_COMPRESSION.html)
+command is used to determine if any of the columns in the table require updating,
 and if so a script is generated to convert to the optimal structure.
 
-Because this utility can make changes to your database live (using the ```--do-execute true``` option), it is highly recommended that you thoroughly test the utility against a dev/test system, and ensure that you take a manual snapshot of Production systems prior to running the generated script. Also, as a large amount of data will be migrated, you should ensure that the migration will not adversely impact Cluster customers. AWS has thoroughly tested this software on a variety of systems, but cannot be responsible for the impact of running the utility against your database. 
+Because this utility can make changes to your database live (using the ```--do-execute true``` option), it is highly recommended that you thoroughly test the utility against a dev/test system, and ensure that you take a manual snapshot of Production systems prior to running the generated script. Also, as a large amount of data will be migrated, you should ensure that the migration will not adversely impact Cluster customers. AWS has thoroughly tested this software on a variety of systems, but cannot be responsible for the impact of running the utility against your database.
 
 ## Data Migration
 
@@ -23,8 +23,8 @@ The script generated will take advantage of one of two data migration options. T
 
 ## Running the Column Encoding Utility
 
-This utility was built and tested on Python 2.7x, but may work with other versions of Python. After cloning this Github project, you must ensure that you have installed the dependencies from [requirements.txt](src/requirements.txt).
- 
+This utility was built and tested on Python 2.7x, but may work with other versions of Python. After cloning this Github project, you must ensure that you have installed the dependencies from [requirements.txt](../requirements.txt).
+
  You can then run the column encoding utility by typing ```python analyze-schema-compression.py``` or ```./analyze-schema-compression.py```. This will generate the following Usage instructions:
 
 ```


### PR DESCRIPTION
*Issue #, if available:* README.md of ColumnEncodingUtility has a hyperlink reference "requirements.txt" pointing to a non-existing location. This is causing some confusion among AWS Redshift customers. 

*Description of changes:*
Changed the relative path to suite the repo structure to an existing location. 

Please review the changes and merge accordingly. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
