### PR TITLE
Add logic to inherit schemaname and tablename from the source if not …

### DIFF
--- a/src/UnloadCopyUtility/tests/cloudformation/scenarios/scenario010/run_test.sh
+++ b/src/UnloadCopyUtility/tests/cloudformation/scenarios/scenario010/run_test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+source ${HOME}/variables.sh
+
+SCENARIO=scenario010
+SOURCE_SCHEMA="ssb"
+SOURCE_TABLE="customer"
+TARGET_SCHEMA="public"
+TARGET_TABLE="${SOURCE_TABLE}"
+PYTHON="python3"
+
+DESCRIPTION="Perform Unload Copy with password encrypted using KMS. "
+DESCRIPTION="${DESCRIPTION}Target table exists in target cluster in different schema. "
+DESCRIPTION="${DESCRIPTION}Force re-creation. "
+DESCRIPTION="${DESCRIPTION}Use ${PYTHON}."
+DESCRIPTION="${DESCRIPTION}Do not specify table in copyTarget."
+
+start_scenario "${DESCRIPTION}"
+
+start_step "Create configuration JSON to copy ${SOURCE_SCHEMA}.${SOURCE_TABLE} of source cluster to ${TARGET_SCHEMA}.${TARGET_TABLE} on target cluster"
+
+cat >${HOME}/${SCENARIO}.json <<EOF
+{
+  "unloadSource": {
+    "clusterEndpoint": "${SourceClusterEndpointAddress}",
+    "clusterPort": ${SourceClusterEndpointPort},
+    "connectPwd": "${KMSEncryptedPassword}",
+    "connectUser": "${SourceClusterMasterUsername}",
+    "db": "${SourceClusterDBName}",
+    "schemaName": "${SOURCE_SCHEMA}",
+    "tableName": "${SOURCE_TABLE}"
+  },
+  "s3Staging": {
+    "aws_iam_role": "${S3CopyRole}",
+    "path": "s3://${CopyUnloadBucket}/${SCENARIO}/",
+    "deleteOnSuccess": "True",
+    "region": "eu-west-1",
+    "kmsGeneratedKey": "True"
+  },
+  "copyTarget": {
+    "clusterEndpoint": "${TargetClusterEndpointAddress}",
+    "clusterPort": ${TargetClusterEndpointPort},
+    "connectPwd": "${KMSEncryptedPassword}",
+    "connectUser": "${SourceClusterMasterUsername}",
+    "db": "${SourceClusterDBName}",
+    "schemaName": "${TARGET_SCHEMA}"
+  }
+}
+EOF
+
+cat ${HOME}/${SCENARIO}.json >>${STDOUTPUT} 2>>${STDERROR}
+r=$? && stop_step $r
+
+start_step "Run Unload Copy Utility"
+source ${VIRTUAL_ENV_PY36_DIR}/bin/activate >>${STDOUTPUT} 2>>${STDERROR}
+cd ${HOME}/amazon-redshift-utils/src/UnloadCopyUtility && ${PYTHON} redshift_unload_copy.py --log-level debug --destination-table-auto-create --destination-table-force-drop-create ${HOME}/${SCENARIO}.json eu-west-1 >>${STDOUTPUT} 2>>${STDERROR}
+psql -h ${TargetClusterEndpointAddress} -p ${TargetClusterEndpointPort} -U ${TargetClusterMasterUsername} ${TargetClusterDBName} -c "select * from stl_ddltext where text ilike 'drop table %${TARGET_SCHEMA}.${TARGET_TABLE}%'" 2>>${STDERROR} | grep -i "drop table" 2>>${STDERROR} | grep -i "${TARGET_SCHEMA}.${TARGET_TABLE}" >>${STDOUTPUT} 2>>${STDERROR}
+RESULT="$?"
+EXPECTED_COUNT=`psql -h ${SourceClusterEndpointAddress} -p ${SourceClusterEndpointPort} -U ${SourceClusterMasterUsername} ${SourceClusterDBName} -c "select 'count='||count(*) from ${SOURCE_SCHEMA}.${SOURCE_TABLE};" | grep "count=[0-9]*"|awk -F= '{ print $2}'`  >>${STDOUTPUT} 2>>${STDERROR}
+psql -h ${TargetClusterEndpointAddress} -p ${TargetClusterEndpointPort} -U ${TargetClusterMasterUsername} ${TargetClusterDBName} -c "select 'count='||count(*) from ${TARGET_SCHEMA}.${TARGET_TABLE};" | grep "count=${EXPECTED_COUNT}" >>${STDOUTPUT} 2>>${STDERROR}
+r=$(( $? + ${RESULT} )) && stop_step $r
+deactivate
+
+stop_scenario

--- a/src/UnloadCopyUtility/tests/cloudformation/scenarios/scenario011/run_test.sh
+++ b/src/UnloadCopyUtility/tests/cloudformation/scenarios/scenario011/run_test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+source ${HOME}/variables.sh
+
+SCENARIO=scenario011
+SOURCE_SCHEMA="ssb"
+SOURCE_TABLE="customer"
+TARGET_SCHEMA="public"
+TARGET_TABLE="${SOURCE_TABLE}"
+PYTHON="python3"
+
+DESCRIPTION="Perform Unload Copy with password encrypted using KMS. "
+DESCRIPTION="${DESCRIPTION}Target table exists in target cluster in different schema. "
+DESCRIPTION="${DESCRIPTION}Force re-creation. "
+DESCRIPTION="${DESCRIPTION}Use ${PYTHON}."
+DESCRIPTION="${DESCRIPTION}Do not specify schema and table in copyTarget."
+
+start_scenario "${DESCRIPTION}"
+
+start_step "Create configuration JSON to copy ${SOURCE_SCHEMA}.${SOURCE_TABLE} of source cluster to ${TARGET_SCHEMA}.${TARGET_TABLE} on target cluster"
+
+cat >${HOME}/${SCENARIO}.json <<EOF
+{
+  "unloadSource": {
+    "clusterEndpoint": "${SourceClusterEndpointAddress}",
+    "clusterPort": ${SourceClusterEndpointPort},
+    "connectPwd": "${KMSEncryptedPassword}",
+    "connectUser": "${SourceClusterMasterUsername}",
+    "db": "${SourceClusterDBName}",
+    "schemaName": "${SOURCE_SCHEMA}",
+    "tableName": "${SOURCE_TABLE}"
+  },
+  "s3Staging": {
+    "aws_iam_role": "${S3CopyRole}",
+    "path": "s3://${CopyUnloadBucket}/${SCENARIO}/",
+    "deleteOnSuccess": "True",
+    "region": "eu-west-1",
+    "kmsGeneratedKey": "True"
+  },
+  "copyTarget": {
+    "clusterEndpoint": "${TargetClusterEndpointAddress}",
+    "clusterPort": ${TargetClusterEndpointPort},
+    "connectPwd": "${KMSEncryptedPassword}",
+    "connectUser": "${SourceClusterMasterUsername}",
+    "db": "${SourceClusterDBName}"
+  }
+}
+EOF
+
+cat ${HOME}/${SCENARIO}.json >>${STDOUTPUT} 2>>${STDERROR}
+r=$? && stop_step $r
+
+start_step "Run Unload Copy Utility"
+source ${VIRTUAL_ENV_PY36_DIR}/bin/activate >>${STDOUTPUT} 2>>${STDERROR}
+cd ${HOME}/amazon-redshift-utils/src/UnloadCopyUtility && ${PYTHON} redshift_unload_copy.py --log-level debug --destination-table-auto-create --destination-table-force-drop-create ${HOME}/${SCENARIO}.json eu-west-1 >>${STDOUTPUT} 2>>${STDERROR}
+psql -h ${TargetClusterEndpointAddress} -p ${TargetClusterEndpointPort} -U ${TargetClusterMasterUsername} ${TargetClusterDBName} -c "select * from stl_ddltext where text ilike 'drop table %${TARGET_SCHEMA}.${TARGET_TABLE}%'" 2>>${STDERROR} | grep -i "drop table" 2>>${STDERROR} | grep -i "${TARGET_SCHEMA}.${TARGET_TABLE}" >>${STDOUTPUT} 2>>${STDERROR}
+RESULT="$?"
+EXPECTED_COUNT=`psql -h ${SourceClusterEndpointAddress} -p ${SourceClusterEndpointPort} -U ${SourceClusterMasterUsername} ${SourceClusterDBName} -c "select 'count='||count(*) from ${SOURCE_SCHEMA}.${SOURCE_TABLE};" | grep "count=[0-9]*"|awk -F= '{ print $2}'`  >>${STDOUTPUT} 2>>${STDERROR}
+psql -h ${TargetClusterEndpointAddress} -p ${TargetClusterEndpointPort} -U ${TargetClusterMasterUsername} ${TargetClusterDBName} -c "select 'count='||count(*) from ${TARGET_SCHEMA}.${TARGET_TABLE};" | grep "count=${EXPECTED_COUNT}" >>${STDOUTPUT} 2>>${STDERROR}
+r=$(( $? + ${RESULT} )) && stop_step $r
+deactivate
+
+stop_scenario

--- a/src/UnloadCopyUtility/util/resources.py
+++ b/src/UnloadCopyUtility/util/resources.py
@@ -360,6 +360,23 @@ class ResourceFactory:
         return ResourceFactory.get_resource_from_dict(cluster_dict, kms_region)
 
     @staticmethod
+    def get_table_resource_from_merging_2_resources(resource1, resource2):
+        cluster = resource1.get_cluster()
+        try:
+            schema = resource1.get_schema()
+        except AttributeError:
+            logging.info('Destination did not have a schema declared fetching from resource2.')
+            schema = resource2.get_schema()
+            logging.info('Using resource2 schema {s}'.format(s=schema))
+        try:
+            table = resource1.get_table()
+        except AttributeError:
+            logging.info('Destination did not have a table declared fetching from resource2.')
+            table = resource2.get_table()
+            logging.info('Using resource2 table {t}'.format(t=table))
+        return TableResource(cluster, schema, table)
+
+    @staticmethod
     def get_target_resource_from_config_helper(config_helper, kms_region=None):
         cluster_dict = config_helper.config['copyTarget']
         return ResourceFactory.get_resource_from_dict(cluster_dict, kms_region)


### PR DESCRIPTION
…specified for the target to avoid failing with error `WARNING:root:'DBResource' object has no attribute 'copy_data'`.

This should be backwards compatible.  Ran all the cloudformation tests and added 2 more scenario's to have coverage for these type of usage.

*Description of changes:*
If in the configuration json there is no target table or schema defined use the same values as the source.  If an unsupported invocation is used then give an exception rather than a message that is not easily understandable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
