### PR TITLE
Redshift ColumnEncodingUtility: Fix crash when reserved word is in column name

### DIFF
--- a/src/ColumnEncodingUtility/analyze-schema-compression.py
+++ b/src/ColumnEncodingUtility/analyze-schema-compression.py
@@ -782,7 +782,7 @@ def analyze(table_info):
                                                                             schema_name,
                                                                             table_name)
                 if len(table_sortkeys) > 0:
-                    insert = "%s order by %s;" % (insert, ",".join(table_sortkeys))
+                    insert = "%s order by \"%s\";" % (insert, ",".join(table_sortkeys).replace(',','\",\"'))
                 else:
                     insert = "%s;" % (insert)
 


### PR DESCRIPTION
Fix crash when reserved word is in column name, related to https://github.com/awslabs/amazon-redshift-utils/issues/329

*Issue #329 *
The script always fails with the following error if one of the column names is called 'time' (perhaps in more cases as well):

```
-- [3033] [3033] Running insert into public."table_$mig"  select * from public."table" order by id,time,action;
Traceback (most recent call last):
  File "./analyze-schema-compression.py", line 420, in run_commands
    cursor.execute(c)
  File "/usr/local/lib/python2.7/site-packages/pg8000/core.py", line 884, in execute
    self._c.execute(self, operation, args)
  File "/usr/local/lib/python2.7/site-packages/pg8000/core.py", line 1839, in execute
    self.handle_messages(cursor)
  File "/usr/local/lib/python2.7/site-packages/pg8000/core.py", line 1978, in handle_messages
    raise self.error
ProgrammingError: (u'ERROR', u'42601', u'syntax error at or near ","', u'141', u'/home/ec2-user/padb/src/pg/src/backend/parser/parser_scan.l', u'707', u'yyerror')

```

The reason is that some columns (like 'time') require double quotes due to them being reserved words.
The following patch seems to fix the problem by changing line 785 from:
`insert = "%s order by %s;" % (insert, ",".join(table_sortkeys))`
To:
`insert = "%s order by \"%s\";" % (insert, ",".join(table_sortkeys).replace(',','\",\"'))`



*Description of changes:*
Enclose all columns in double quotes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
