### PR TITLE
feat: Emptyasnull in copy command

### DIFF
--- a/src/UnloadCopyUtility/util/resources.py
+++ b/src/UnloadCopyUtility/util/resources.py
@@ -271,6 +271,7 @@ class TableResource(SchemaResource):
                      manifest
                      encrypted
                      gzip
+                     null as 'NULL_STRING__'
                      delimiter '^' addquotes escape allowoverwrite"""
 
     copy_table_stmt = """copy {schema_name}.{table_name} {columns}
@@ -279,6 +280,7 @@ class TableResource(SchemaResource):
                    manifest 
                    encrypted
                    gzip 
+                   null as 'NULL_STRING__'
                    {explicit_ids}
                    delimiter '^' removequotes escape compupdate off """
 


### PR DESCRIPTION
Redshift UNLOADs nulls as empty strings by default: 
https://docs.aws.amazon.com/redshift/latest/dg/r_UNLOAD_command_examples.html

This loads empty strings when used in COPY command. 

This PR adds `null as 'NULL_STRING__'` to the copy and unload commands. 