### PR TITLE
Users that install a Python library become onwer of that library

### DIFF
--- a/src/AdminViews/v_find_dropuser_objs.sql
+++ b/src/AdminViews/v_find_dropuser_objs.sql
@@ -78,13 +78,13 @@ AND   nc.nspname NOT ILIKE 'pg\_temp\_%') OWNER ("objtype","objowner","userid","
 WHERE owner.userid > 1
 UNION ALL
 -- Python libraries owned by the user
-SELECT 
-      'Library',
-  pgu.usename,
-  pgu.usesysid,
-  '',
-    pgl.name,
-  'No DDL avaible for Python Library. You should DROP OR REPLACE the Python Library'
-FROM pg_library pgl
-INNER JOIN pg_user pgu ON pgl.owner = pgu.usesysid;
+SELECT 'Library',
+       pgu.usename,
+       pgu.usesysid,
+       '',
+       pgl.name,
+       'No DDL avaible for Python Library. You should DROP OR REPLACE the Python Library'
+FROM  pg_library pgl,
+      pg_user pgu
+WHERE pgl.owner = pgu.usesysid;
 

--- a/src/AdminViews/v_find_dropuser_objs.sql
+++ b/src/AdminViews/v_find_dropuser_objs.sql
@@ -74,8 +74,7 @@ FROM pg_class pgc,
 WHERE pgc.relnamespace = nc.oid
 AND   pgc.relkind IN ('r','v')
 AND   pgu.usesysid = pgc.relowner
-AND   nc.nspname NOT ILIKE 'pg\_temp\_%') OWNER ("objtype","objowner","userid","schemaname","objname","ddl") 
-WHERE owner.userid > 1
+AND   nc.nspname NOT ILIKE 'pg\_temp\_%'
 UNION ALL
 -- Python libraries owned by the user
 SELECT 'Library',
@@ -86,5 +85,6 @@ SELECT 'Library',
        'No DDL avaible for Python Library. You should DROP OR REPLACE the Python Library'
 FROM  pg_library pgl,
       pg_user pgu
-WHERE pgl.owner = pgu.usesysid;
+WHERE pgl.owner = pgu.usesysid) OWNER ("objtype","objowner","userid","schemaname","objname","ddl") 
+WHERE owner.userid > 1;
 

--- a/src/AdminViews/v_find_dropuser_objs.sql
+++ b/src/AdminViews/v_find_dropuser_objs.sql
@@ -16,7 +16,7 @@ History:
 2018-01-06 adedotua added ddl column to generate ddl for transferring object ownership
 2018-01-15 pvbouwel Add QUOTE_IDENT for identifiers
 2018-05-29 adedotua added filter to skip temp tables
-2018-08-03 alexlsts added filter to skip temp tables
+2018-08-03 alexlsts added pg_library
 
 **********************************************************************************************/
 

--- a/src/AdminViews/v_find_dropuser_objs.sql
+++ b/src/AdminViews/v_find_dropuser_objs.sql
@@ -16,7 +16,7 @@ History:
 2018-01-06 adedotua added ddl column to generate ddl for transferring object ownership
 2018-01-15 pvbouwel Add QUOTE_IDENT for identifiers
 2018-05-29 adedotua added filter to skip temp tables
-2018-08-03 alexlsts added pg_library
+2018-08-03 alexlsts added pg_library with custom message in ddl column
 
 **********************************************************************************************/
 

--- a/src/AdminViews/v_find_dropuser_objs.sql
+++ b/src/AdminViews/v_find_dropuser_objs.sql
@@ -16,7 +16,7 @@ History:
 2018-01-06 adedotua added ddl column to generate ddl for transferring object ownership
 2018-01-15 pvbouwel Add QUOTE_IDENT for identifiers
 2018-05-29 adedotua added filter to skip temp tables
-2018-08-03 alexlsts added pg_library with custom message in ddl column
+2018-08-03 alexlsts added table pg_library with custom message in ddl column
 
 **********************************************************************************************/
 


### PR DESCRIPTION
Description of changes:

I have included the table PG_LIBRARY where We can find if the user owns a library. 
As the library is available for users to incorporate when creating a user-defined function I am not generating DDL for drop it and instead I am displaying the message "No DDL avaible for Python Library. You should DROP OR REPLACE the Python Library"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
