### PR TITLE
Users that install a Python library become owner of that library

### DIFF
--- a/src/AdminViews/v_find_dropuser_objs.sql
+++ b/src/AdminViews/v_find_dropuser_objs.sql
@@ -78,13 +78,13 @@ AND   nc.nspname NOT ILIKE 'pg\_temp\_%') OWNER ("objtype","objowner","userid","
 WHERE owner.userid > 1
 UNION ALL
 -- Python libraries owned by the user
-SELECT 
-      'Library',
-  pgu.usename,
-  pgu.usesysid,
-  '',
-    pgl.name,
-  'No DDL avaible for Python Library. You should DROP OR REPLACE the Python Library'
-FROM pg_library pgl
-INNER JOIN pg_user pgu ON pgl.owner = pgu.usesysid;
+SELECT 'Library',
+       pgu.usename,
+       pgu.usesysid,
+       '',
+       pgl.name,
+       'No DDL avaible for Python Library. You should DROP OR REPLACE the Python Library'
+FROM  pg_library pgl,
+      pg_user pgu
+WHERE pgl.owner = pgu.usesysid;
 

--- a/src/AdminViews/v_find_dropuser_objs.sql
+++ b/src/AdminViews/v_find_dropuser_objs.sql
@@ -74,8 +74,7 @@ FROM pg_class pgc,
 WHERE pgc.relnamespace = nc.oid
 AND   pgc.relkind IN ('r','v')
 AND   pgu.usesysid = pgc.relowner
-AND   nc.nspname NOT ILIKE 'pg\_temp\_%') OWNER ("objtype","objowner","userid","schemaname","objname","ddl") 
-WHERE owner.userid > 1
+AND   nc.nspname NOT ILIKE 'pg\_temp\_%'
 UNION ALL
 -- Python libraries owned by the user
 SELECT 'Library',
@@ -86,5 +85,6 @@ SELECT 'Library',
        'No DDL avaible for Python Library. You should DROP OR REPLACE the Python Library'
 FROM  pg_library pgl,
       pg_user pgu
-WHERE pgl.owner = pgu.usesysid;
+WHERE pgl.owner = pgu.usesysid) OWNER ("objtype","objowner","userid","schemaname","objname","ddl") 
+WHERE owner.userid > 1;
 

--- a/src/AdminViews/v_find_dropuser_objs.sql
+++ b/src/AdminViews/v_find_dropuser_objs.sql
@@ -16,7 +16,7 @@ History:
 2018-01-06 adedotua added ddl column to generate ddl for transferring object ownership
 2018-01-15 pvbouwel Add QUOTE_IDENT for identifiers
 2018-05-29 adedotua added filter to skip temp tables
-2018-08-03 alexlsts added filter to skip temp tables
+2018-08-03 alexlsts added pg_library
 
 **********************************************************************************************/
 

--- a/src/AdminViews/v_find_dropuser_objs.sql
+++ b/src/AdminViews/v_find_dropuser_objs.sql
@@ -16,7 +16,7 @@ History:
 2018-01-06 adedotua added ddl column to generate ddl for transferring object ownership
 2018-01-15 pvbouwel Add QUOTE_IDENT for identifiers
 2018-05-29 adedotua added filter to skip temp tables
-2018-08-03 alexlsts added pg_library
+2018-08-03 alexlsts added pg_library with custom message in ddl column
 
 **********************************************************************************************/
 

--- a/src/AdminViews/v_find_dropuser_objs.sql
+++ b/src/AdminViews/v_find_dropuser_objs.sql
@@ -16,7 +16,7 @@ History:
 2018-01-06 adedotua added ddl column to generate ddl for transferring object ownership
 2018-01-15 pvbouwel Add QUOTE_IDENT for identifiers
 2018-05-29 adedotua added filter to skip temp tables
-2018-08-03 alexlsts added pg_library with custom message in ddl column
+2018-08-03 alexlsts added table pg_library with custom message in ddl column
 
 **********************************************************************************************/
 

--- a/src/AdminViews/v_generate_view_ddl.sql
+++ b/src/AdminViews/v_generate_view_ddl.sql
@@ -4,6 +4,7 @@ Purpose: View to get the DDL for a view.
 History:
 2014-02-10 jjschmit Created
 2018-01-15 pvbouwel Replace tabs and add QUOTE_IDENT for identifiers (schema and view names)
+2018-08-03 alexlsts Included CASE to check for late binding view 
 **********************************************************************************************/
 CREATE OR REPLACE VIEW admin.v_generate_view_ddl
 AS
@@ -11,11 +12,12 @@ SELECT
     n.nspname AS schemaname
     ,c.relname AS viewname
     ,'--DROP VIEW ' + QUOTE_IDENT(n.nspname) + '.' + QUOTE_IDENT(c.relname) + ';\n'
-    + 'CREATE OR REPLACE VIEW ' + QUOTE_IDENT(n.nspname) + '.' + QUOTE_IDENT(c.relname) + ' AS\n' + COALESCE(pg_get_viewdef(c.oid, TRUE), '') AS ddl
+    + CASE 
+     	WHEN c.relnatts > 0 then 'CREATE OR REPLACE VIEW ' + QUOTE_IDENT(n.nspname) + '.' + QUOTE_IDENT(c.relname) + ' AS\n' + COALESCE(pg_get_viewdef(c.oid, TRUE), '')
+     	ELSE  COALESCE(pg_get_viewdef(c.oid, TRUE), '') END AS ddl
 FROM 
     pg_catalog.pg_class AS c
 INNER JOIN
     pg_catalog.pg_namespace AS n
     ON c.relnamespace = n.oid
-WHERE relkind = 'v'
-;
+WHERE relkind = 'v';

--- a/src/AdminViews/v_space_used_per_tbl.sql
+++ b/src/AdminViews/v_space_used_per_tbl.sql
@@ -5,12 +5,13 @@ History:
 2014-01-30 jjschmit Created
 2014-02-18 jjschmit Removed hardcoded where clause against 'public' schema
 2014-02-21 jjschmit Added pct_unsorted and recommendation fields
-2015-03-31 tinkerbotfoo Handled a special case to avoid divide by zero for pct_unsorted 
+2015-03-31 tinkerbotfoo Handled a special case to avoid divide by zero for pct_unsorted
+2018-08-10 alexlsts Changed column "tablename" to use "relname" column from pg_class  
 **********************************************************************************************/
 CREATE OR REPLACE VIEW admin.v_space_used_per_tbl
 AS with info_table as ( SELECT TRIM(pgdb.datname) AS dbase_name
         ,TRIM(pgn.nspname) as schemaname
-        ,TRIM(a.name) AS tablename
+        ,TRIM(pgc.relname) AS tablename
         ,id AS tbl_oid
         ,b.mbytes AS megabytes
        ,CASE WHEN pgc.reldiststyle = 8


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

I have included the table PG_LIBRARY where We can find if the user owns a library.
As the library is available for users to incorporate when creating a user-defined function I am not generating DDL for drop it and instead I am displaying the message "No DDL available for Python Library. You should DROP OR REPLACE the Python Library"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
