### PR TITLE
Exit on errors (to catch faults in caller of the script)

### DIFF
--- a/src/bin/entrypoint.sh
+++ b/src/bin/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 PROJECT=${1:-}
 
 if [ "${PROJECT}" == "analyze-vacuum" ]; then bin/run-analyze-vacuum-utility.sh

--- a/src/bin/run-analyze-vacuum-utility.sh
+++ b/src/bin/run-analyze-vacuum-utility.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 echo "Running analyze-vacuum utility"
 
 # Required

--- a/src/bin/run-column-encoding-utility.sh
+++ b/src/bin/run-column-encoding-utility.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 echo "Running column-encoding utility"
 
 # Required

--- a/src/bin/run-unload-copy-utility.sh
+++ b/src/bin/run-unload-copy-utility.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 echo "Running unload-copy utility"
 
 # Required


### PR DESCRIPTION
*Description of changes:*

Add `set -e` to shell scripts, in order pass exit code to caller of the scripts. This allows, for example, ECS task to show failure status, without needing the verify from Cloudwatch logs if the utility ran succesfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
