### PR TITLE
Remove duplicate --statement-timeout option

### DIFF
--- a/src/bin/run-column-encoding-utility.sh
+++ b/src/bin/run-column-encoding-utility.sh
@@ -65,7 +65,6 @@ else
         --force ${FORCE} \
         --drop-old-data ${DROP_OLD_DATA} \
         --ssl-option ${SSL_OPTION} \
-        --statement-timeout ${STATEMENT_TIMEOUT} \
         ${ANALYZE_TABLE_CMD} ${ANALYZE_COL_WIDTH_CMD} ${OUTPUT_FILE_CMD} ${COMP_ROWS_CMD} ${QUERY_GROUP_CMD} \
         ${NEW_DIST_KEY_CMD} ${NEW_SORT_KEYS_CMD} ${STATEMENT_TIMEOUT_CMD}
 


### PR DESCRIPTION
*Description of changes:* 
This fixes run-column-encoding-utility.sh script to work also when the environment variable STATEMENT_TIMEOUT is not defined. Previously this resulted in an "option --statement-timeout requires argument" error message. Using ${STATEMENT_TIMEOUT_CMD} will only insert the option when the environment variable is defined.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.