### PR TITLE
Adding Decode step after the kms decrypt for the secret key & key to remove SQL generation error

### DIFF
--- a/src/UnloadCopyUtility/util/s3_utils.py
+++ b/src/UnloadCopyUtility/util/s3_utils.py
@@ -143,8 +143,8 @@ class S3Details:
                 self.access_credentials = S3AccessCredentialsRole(role)
             elif 'aws_access_key_id' in s3_staging_conf and 'aws_secret_access_key' in s3_staging_conf:
                 kms_helper = KMSHelper(config_helper.s3_helper.region_name)
-                key_id = kms_helper.decrypt(s3_staging_conf['aws_access_key_id'])
-                secret_key = kms_helper.decrypt(s3_staging_conf['aws_secret_access_key'])
+                key_id = kms_helper.decrypt(s3_staging_conf['aws_access_key_id']).decode('utf-8')
+                secret_key = kms_helper.decrypt(s3_staging_conf['aws_secret_access_key']).decode('utf-8')
                 self.access_credentials = S3AccessCredentialsKey(key_id, secret_key)
             else:
                 raise(S3Details.NoS3CredentialsFoundException())


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*

System:

```
python3 --version
Python 3.6.5
```

AWS Cli
```
aws --version
aws-cli/1.16.2 Python/3.6.5 Darwin/17.7.0 botocore/1.11.2
```

When running the command to unload/copy I'd get the following error (values redacted)

```
INFO:root:unload ('SELECT * FROM MYSCHEMA.MYTABLE')
                     to 's3://somevalue' credentials 
                     'aws_access_key_id=b'SOME_STRING';aws_secret_access_key=REDACTED';master_symmetric_key=REDACTED'
                     manifest
                     encrypted
                     gzip
                     null as 'NULL_STRING__'
```

The output of the KMS decrypt steps is still a byte object, not a string so during the format it would break (b'some_value'). I added decrypt before the construction of the credential object and everything went back to normal.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
