### PR TITLE
Alter command fails when table doesn't exist

### DIFF
--- a/src/SystemTablePersistence/lib/history_table_creation.sql
+++ b/src/SystemTablePersistence/lib/history_table_creation.sql
@@ -24,7 +24,6 @@ CREATE TABLE IF NOT EXISTS history.hist_svl_query_summary
     is_delayed_scan   CHARACTER(1) ENCODE zstd,
     rows_pre_filter   BIGINT ENCODE zstd
   );
-ALTER TABLE HISTORY.hist_svl_s3query_summary add column is_nested text default null;
 CREATE TABLE IF NOT EXISTS history.hist_svl_s3query_summary
   (
     userid                   integer,
@@ -61,6 +60,7 @@ CREATE TABLE IF NOT EXISTS history.hist_svl_s3query_summary
     max_request_parallelism  integer,
     avg_request_parallelism  double precision
   );
+ALTER TABLE HISTORY.hist_svl_s3query_summary add column is_nested text default null;
 CREATE TABLE IF NOT EXISTS HISTORY.HIST_SVL_S3QUERY
   (
     userid                   integer,


### PR DESCRIPTION
*Issue #, if available:*
```
create schema if not exists history
CREATE TABLE IF NOT EXISTS history.hist_stl_load_errors (LIKE STL_LOAD_ERRORS)
CREATE TABLE IF NOT EXISTS history.hist_stl_query (LIKE stl_query)
CREATE TABLE IF NOT EXISTS history.hist_stl_wlm_query (LIKE stl_wlm_query)
CREATE TABLE IF NOT EXISTS history.hist_stl_explain (LIKE stl_explain)
CREATE TABLE IF NOT EXISTS history.hist_svl_query_summary
  (
    userid            INTEGER ENCODE zstd,
    query             INTEGER ENCODE zstd,
    stm               INTEGER ENCODE zstd,
    seg               INTEGER ENCODE zstd,
    step              INTEGER ENCODE zstd,
    maxtime           BIGINT ENCODE zstd,
    avgtime           BIGINT ENCODE zstd,
    ROWS              BIGINT ENCODE zstd,
    bytes             BIGINT ENCODE zstd,
    rate_row          DOUBLE precision ENCODE zstd,
    rate_byte         DOUBLE precision ENCODE zstd,
    label             TEXT ENCODE zstd,
    is_diskbased      CHARACTER(1) ENCODE zstd,
    workmem           BIGINT ENCODE zstd,
    is_rrscan         CHARACTER(1) ENCODE zstd,
    is_delayed_scan   CHARACTER(1) ENCODE zstd,
    rows_pre_filter   BIGINT ENCODE zstd
  )
ALTER TABLE HISTORY.hist_svl_s3query_summary add column is_nested text default null
(u'ERROR', u'42P01', u'relation "history.hist_svl_s3query_summary" does not exist', u'/home/ec2-user/padb/src/pg/src/backend/catalog/namespace.c', u'232', u'RangeVarGetRelid')
Traceback (most recent call last):
  File "./ra", line 116, in <module>
    cli(args.utility, args.config, use_region)
  File "./ra", line 96, in cli
    snapshot_system_stats.snapshot([config, os.environ])
  File "./lib/SystemTablePersistence/snapshot_system_stats.py", line 248, in snapshot
    create_schema_objects(cursor, conn)
  File "./lib/SystemTablePersistence/snapshot_system_stats.py", line 75, in create_schema_objects
    raise e
pg8000.core.ProgrammingError: (u'ERROR', u'42P01', u'relation "history.hist_svl_s3query_summary" does not exist', u'/home/ec2-user/padb/src/pg/src/backend/catalog/namespace.c', u'232', u'RangeVarGetRelid')
```
*Description of changes:*
Switching the ALTER statement after the creation of the table.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
