### PR TITLE
Update pwd only if .pgpass file  exists otherwise will be set to None

### DIFF
--- a/src/SystemTablePersistence/snapshot_system_stats.py
+++ b/src/SystemTablePersistence/snapshot_system_stats.py
@@ -186,7 +186,9 @@ def snapshot(config_sources):
 
     # override the password with the contents of .pgpass or environment variables
     try:
-        pwd = pgpasslib.getpass(host, port, database, user)
+        pg_pwd = pgpasslib.getpass(host, port, database, user)
+        if pg_pwd:
+            pwd = pg_pwd
     except pgpasslib.FileNotFound as e:
         pass
 


### PR DESCRIPTION
*Issue #, if available:*

if the .pgpass file doesn't exist the pwd variable will be set to None, so erases it.


*Description of changes:*

Doesn't reset the variable if there is no new password.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
