### PR TITLE
used `or replace` in two view scripts  so creation of views can be re-ran without error messages

### DIFF
--- a/src/AdminViews/v_my_last_copy_errors.sql
+++ b/src/AdminViews/v_my_last_copy_errors.sql
@@ -8,7 +8,7 @@ History:
 
 **********************************************************************************************/
 
-create view admin.v_my_last_copy_errors as 
+create or replace view admin.v_my_last_copy_errors as 
 select query, 
        starttime,
        filename, 

--- a/src/AdminViews/v_my_last_query_summary.sql
+++ b/src/AdminViews/v_my_last_query_summary.sql
@@ -10,7 +10,7 @@ History:
 
 **********************************************************************************************/
 
-create view admin.v_my_last_query_summary as 
+create or replace view admin.v_my_last_query_summary as 
 select query,
        maxtime, 
        avgtime, 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* replaced `create view` with `create or replace view` so the two `my_` views can be ran a second time, since running all of the scripts twice to satisfy dependencies is a normal means of creating all of the views (but those two views report error messages since they already exist).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
