### PR TITLE
 ColumnEncodingUtility : Fix sortkey related issues

### DIFF
--- a/src/ColumnEncodingUtility/analyze-schema-compression.py
+++ b/src/ColumnEncodingUtility/analyze-schema-compression.py
@@ -627,6 +627,7 @@ def analyze(table_info):
             table_sortkeys = []
             new_sortkey_arr = [t.strip() for t in new_sort_keys.split(',')] if new_sort_keys is not None else []
 
+
             # count of suggested optimizations
             count_optimized = 0
             # process each item given back by the analyze request
@@ -634,9 +635,11 @@ def analyze(table_info):
                 if debug:
                     comment("Analyzed Compression Row State: %s" % str(row))
                 col = row[1]
+                row_sortkey = descr[col][4]
 
                 # compare the previous encoding to the new encoding
-                new_encoding = row[2]
+                # don't use new encoding for first sortkey
+                new_encoding = row[2] if not abs(row_sortkey) == 1 else 'raw'
                 old_encoding = descr[col][2]
                 old_encoding = 'raw' if old_encoding == 'none' else old_encoding
                 if new_encoding != old_encoding:
@@ -675,7 +678,6 @@ def analyze(table_info):
                         distkey = ''
 
                 # link in the existing sort keys, or set the new ones
-                row_sortkey = descr[col][4]
                 if table_name is not None and len(new_sortkey_arr) > 0:
                     if col in new_sortkey_arr:
                         sortkeys[new_sortkey_arr.index(col) + 1] = col

--- a/src/ColumnEncodingUtility/analyze-schema-compression.py
+++ b/src/ColumnEncodingUtility/analyze-schema-compression.py
@@ -799,7 +799,7 @@ def analyze(table_info):
                                                                             schema_name,
                                                                             table_name)
                 if len(table_sortkeys) > 0:
-                    insert = "%s order by \"%s\";" % (insert, ",".join(new_sortkey_arr).replace(',','\",\"'))
+                    insert = "%s order by \"%s\";" % (insert, ",".join(table_sortkeys).replace(',','\",\"'))
                 else:
                     insert = "%s;" % (insert)
 

--- a/src/ColumnEncodingUtility/analyze-schema-compression.py
+++ b/src/ColumnEncodingUtility/analyze-schema-compression.py
@@ -580,6 +580,8 @@ def analyze(table_info):
             while attempt_count < analyze_retry and analyze_compression_result is None:
                 try:
                     analyze_compression_result = execute_query(statement)
+                    # Commiting otherwise anaylze keep an exclusive lock until a commit arrive which can be very long
+                    execute_query('commit;')
                 except KeyboardInterrupt:
                     # To handle Ctrl-C from user
                     cleanup(get_pg_conn())


### PR DESCRIPTION
*Issue #, if available:*
- Create table ORDER BY was not working properly if we didn't explicitly specified a new sortkey
- Tables with sortkey were always recreated if ANALYZE was suggesting a different encoding than RAW for the first column of the sortkey even thought no other encoding changed.

*Description of changes:*
- Fixing the order by by using the same columns for the sortkey as the ones used to recreate the table.
- Ignore the suggested encoding for the first column of the sortkey as we want it to always be RAW.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
