### PR TITLE
Add stl query metrics

### DIFF
--- a/src/SystemTablePersistence/lib/history_table_config.json
+++ b/src/SystemTablePersistence/lib/history_table_config.json
@@ -39,5 +39,5 @@
     "snapshotNew": "select * from stl_query_metrics  where starttime > (select nvl(max(starttime), '01/01/1970'::TIMESTAMP) from history.hist_stl_query_metrics)",
     "archiveColumn": "starttime"
   }
-  
 ]
+        

--- a/src/SystemTablePersistence/lib/history_table_config.json
+++ b/src/SystemTablePersistence/lib/history_table_config.json
@@ -34,5 +34,5 @@
     "snapshotNew": "select userid, query, segment, step, node, slice, starttime, endtime, elapsed, external_table_name, file_format, is_partitioned, is_rrscan, s3_scanned_rows, s3_scanned_bytes, s3query_returned_rows, s3query_returned_bytes, files, splits, total_split_size, max_split_size, total_retries, max_retries, max_request_duration, avg_request_duration, max_request_parallelism, avg_request_parallelism,is_nested from svl_s3query where starttime > (select nvl(max(starttime), '01/01/1970'::timestamp) from history.hist_svl_s3query)",
     "archiveColumn": "starttime"
   }
+  
 ]
-        

--- a/src/SystemTablePersistence/lib/history_table_config.json
+++ b/src/SystemTablePersistence/lib/history_table_config.json
@@ -33,6 +33,11 @@
     "table": "hist_svl_s3query",
     "snapshotNew": "select userid, query, segment, step, node, slice, starttime, endtime, elapsed, external_table_name, file_format, is_partitioned, is_rrscan, s3_scanned_rows, s3_scanned_bytes, s3query_returned_rows, s3query_returned_bytes, files, splits, total_split_size, max_split_size, total_retries, max_retries, max_request_duration, avg_request_duration, max_request_parallelism, avg_request_parallelism,is_nested from svl_s3query where starttime > (select nvl(max(starttime), '01/01/1970'::timestamp) from history.hist_svl_s3query)",
     "archiveColumn": "starttime"
+  },
+  {
+    "table": "hist_stl_query_metrics",
+    "snapshotNew": "select * from stl_query_metrics  where starttime > (select nvl(max(starttime), '01/01/1970'::TIMESTAMP) from history.hist_stl_query_metrics)",
+    "archiveColumn": "starttime"
   }
   
 ]

--- a/src/SystemTablePersistence/lib/history_table_creation.sql
+++ b/src/SystemTablePersistence/lib/history_table_creation.sql
@@ -116,3 +116,5 @@ CREATE TABLE IF NOT EXISTS history.HIST_SVL_S3QUERY
     avg_request_parallelism  DOUBLE PRECISION
   );
 ALTER TABLE history.hist_svl_s3query ADD COLUMN is_nested TEXT DEFAULT NULL;
+
+CREATE TABLE IF NOT EXISTS history.hist_stl_query_metrics (like stl_query_metrics);


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-redshift-utils/issues/354
*Description of changes:*
Add the stl_query_metrics in systemTablePersistence

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
