### PR TITLE
Update analyze-vacuum-schema.py

### DIFF
--- a/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
+++ b/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
@@ -78,7 +78,7 @@ def usage(with_message=None):
     print('           --db-port            - The Cluster endpoint port : Default = 5439')
     print('           --db-conn-opts       - Additional connection options. "name1=opt1[ name2=opt2].."')
     print('           --require-ssl        - Does the connection require SSL? (True | False)')
-    print('           --schema-name        - The Schema to be Analyzed or Vacuumed : Default = public')
+    print('           --schema-name        - The Schema to be Analyzed or Vacuumed (REGEX): Default = public') 
     print('           --table-name         - A specific table to be Analyzed or Vacuumed, if --analyze-schema is not desired')
     print('           --blacklisted-tables - The tables we do not want to Vacuum')
     print('           --output-file        - The full path to the output file to be generated')


### PR DESCRIPTION
*Issue #, if available:*
The doc doesn't specify it's a regex so you can select other schemas thinking it's doing a`where schemaname= 'myschema'`. 
It's using a regex https://github.com/awslabs/amazon-redshift-utils/blob/master/src/AnalyzeVacuumUtility/lib/analyze_vacuum.py#L211

*Description of changes:*
Add the argument type in the doc

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
