### PR TITLE
Multi table copy

### DIFF
--- a/src/UnloadCopyUtility/redshift_unload_copy.py
+++ b/src/UnloadCopyUtility/redshift_unload_copy.py
@@ -95,16 +95,16 @@ class UnloadCopyTool:
                 dest_config['tableName'] = dest_tables[idx]
                 source = ResourceFactory.get_source_resource_from_config_helper(self.config_helper, self.region)
                 destination = ResourceFactory.get_target_resource_from_config_helper(self.config_helper, self.region)
-                self.add_src_dest_tasks(source,destination,task_manager)
+                self.add_src_dest_tasks(source,destination)
         else:
             # Migrating a single table
             source = ResourceFactory.get_source_resource_from_config_helper(self.config_helper, self.region)
             destination = ResourceFactory.get_target_resource_from_config_helper(self.config_helper, self.region)
-            self.add_src_dest_tasks(source,destination,task_manager)
+            self.add_src_dest_tasks(source,destination)
 
         self.task_manager.run()
 
-    def add_src_dest_tasks(self,source,destination, task_manager):
+    def add_src_dest_tasks(self,source,destination):
         # TODO: Check whether both resources are of type table if that is not the case then perform other scenario's
         if isinstance(source, TableResource):
             if isinstance(destination, DBResource):

--- a/src/UnloadCopyUtility/redshift_unload_copy.py
+++ b/src/UnloadCopyUtility/redshift_unload_copy.py
@@ -81,8 +81,8 @@ class UnloadCopyTool:
         self.barrier_after_all_resource_pre_tests = NoOperationTask()
         self.task_manager.add_task(self.barrier_after_all_resource_pre_tests)
 
-        src_config = config_helper.config['unloadSource']
-        dest_config = config_helper.config['copyTarget']
+        src_config = self.config_helper.config['unloadSource']
+        dest_config = self.config_helper.config['copyTarget']
         if(src_config['tableNames']):
             src_tables = src_config['tableNames']
             dest_tables = dest_config['tableNames']

--- a/src/UnloadCopyUtility/redshift_unload_copy.py
+++ b/src/UnloadCopyUtility/redshift_unload_copy.py
@@ -95,16 +95,16 @@ class UnloadCopyTool:
                 dest_config['tableName'] = dest_tables[idx]
                 source = ResourceFactory.get_source_resource_from_config_helper(self.config_helper, self.region)
                 destination = ResourceFactory.get_target_resource_from_config_helper(self.config_helper, self.region)
-                self.add_src_dest_tasks(source,destination)
+                self.add_src_dest_tasks(source,destination,global_config_values)
         else:
             # Migrating a single table
             source = ResourceFactory.get_source_resource_from_config_helper(self.config_helper, self.region)
             destination = ResourceFactory.get_target_resource_from_config_helper(self.config_helper, self.region)
-            self.add_src_dest_tasks(source,destination)
+            self.add_src_dest_tasks(source,destination,global_config_values)
 
         self.task_manager.run()
 
-    def add_src_dest_tasks(self,source,destination):
+    def add_src_dest_tasks(self,source,destination,global_config_values):
         # TODO: Check whether both resources are of type table if that is not the case then perform other scenario's
         if isinstance(source, TableResource):
             if isinstance(destination, DBResource):

--- a/src/UnloadCopyUtility/redshift_unload_copy.py
+++ b/src/UnloadCopyUtility/redshift_unload_copy.py
@@ -90,7 +90,7 @@ class UnloadCopyTool:
             if( not dest_tables or len(src_tables) != len(dest_tables) ):
                 logging.fatal("When migrating multiple tables 'tableNames' property must be configured in unloadSource and copyTarget, and be the same length")
                 raise NotImplementedError
-            for(idx in range(0,len(src_tables))):
+            for idx in range(0,len(src_tables)):
                 src_config['tableName'] = src_tables[idx]
                 dest_config['tableName'] = dest_tables[idx]
                 source = ResourceFactory.get_source_resource_from_config_helper(self.config_helper, self.region)

--- a/src/UnloadCopyUtility/redshift_unload_copy.py
+++ b/src/UnloadCopyUtility/redshift_unload_copy.py
@@ -75,16 +75,36 @@ class UnloadCopyTool:
         # load the configuration
         self.config_helper = ConfigHelper(config_file, self.s3_helper)
 
-        source = ResourceFactory.get_source_resource_from_config_helper(self.config_helper, self.region)
-
-        destination = ResourceFactory.get_target_resource_from_config_helper(self.config_helper, self.region)
-
         self.task_manager = TaskManager()
         self.barrier_after_all_cluster_pre_tests = NoOperationTask()
         self.task_manager.add_task(self.barrier_after_all_cluster_pre_tests)
         self.barrier_after_all_resource_pre_tests = NoOperationTask()
         self.task_manager.add_task(self.barrier_after_all_resource_pre_tests)
 
+        src_config = config_helper.config['unloadSource']
+        dest_config = config_helper.config['copyTarget']
+        if(src_config['tableNames']):
+            src_tables = src_config['tableNames']
+            dest_tables = dest_config['tableNames']
+            logging.info("Migrating multiple tables")
+            if(!dest_tables or len(src_tables) != len(dest_tables) ):
+                logging.fatal("When migrating multiple tables 'tableNames' property must be configured in unloadSource and copyTarget, and be the same length")
+                raise NotImplementedError
+            for(idx in range(0,len(src_tables))):
+                src_config['tableName'] = src_tables[idx]
+                dest_config['tableName'] = dest_tables[idx]
+                source = ResourceFactory.get_source_resource_from_config_helper(self.config_helper, self.region)
+                destination = ResourceFactory.get_target_resource_from_config_helper(self.config_helper, self.region)
+                self.add_src_dest_tasks(source,destination,task_manager)
+        else:
+            # Migrating a single table
+            source = ResourceFactory.get_source_resource_from_config_helper(self.config_helper, self.region)
+            destination = ResourceFactory.get_target_resource_from_config_helper(self.config_helper, self.region)
+            self.add_src_dest_tasks(source,destination,task_manager)
+
+        self.task_manager.run()
+
+    def add_src_dest_tasks(self,source,destination, task_manager):
         # TODO: Check whether both resources are of type table if that is not the case then perform other scenario's
         if isinstance(source, TableResource):
             if isinstance(destination, DBResource):
@@ -103,7 +123,6 @@ class UnloadCopyTool:
             logging.fatal('Source is not a Table, this type of unload-copy is currently not supported.')
             raise NotImplementedError
 
-        self.task_manager.run()
 
     def add_table_migration(self, source, destination, global_config_values):
         if global_config_values['connectionPreTest']:

--- a/src/UnloadCopyUtility/redshift_unload_copy.py
+++ b/src/UnloadCopyUtility/redshift_unload_copy.py
@@ -87,7 +87,7 @@ class UnloadCopyTool:
             src_tables = src_config['tableNames']
             dest_tables = dest_config['tableNames']
             logging.info("Migrating multiple tables")
-            if(!dest_tables or len(src_tables) != len(dest_tables) ):
+            if( not dest_tables or len(src_tables) != len(dest_tables) ):
                 logging.fatal("When migrating multiple tables 'tableNames' property must be configured in unloadSource and copyTarget, and be the same length")
                 raise NotImplementedError
             for(idx in range(0,len(src_tables))):

--- a/src/UnloadCopyUtility/util/redshift_cluster.py
+++ b/src/UnloadCopyUtility/util/redshift_cluster.py
@@ -12,7 +12,7 @@ from pg import connect
 
 options = "keepalives=1 keepalives_idle=200 keepalives_interval=200 keepalives_count=6 connect_timeout=10"
 
-set_timeout_stmt = "set statement_timeout = 1200000"
+set_timeout_stmt = "set statement_timeout = 0"
 
 
 class RedshiftClusterFactory:

--- a/src/UnloadCopyUtility/util/resources.py
+++ b/src/UnloadCopyUtility/util/resources.py
@@ -282,6 +282,8 @@ class TableResource(SchemaResource):
                    gzip 
                    null as 'NULL_STRING__'
                    {explicit_ids}
+                   dateformat 'auto'
+                   timeformat 'auto'
                    delimiter '^' removequotes escape compupdate off """
 
     drop_table_stmt = """DROP TABLE {schema_name}.{table_name}"""


### PR DESCRIPTION
*Issue #, if available:*
#369 

*Description of changes:*
* Adds support for migrating multiple tables within a single schema at the same time.
* Disables query timeout during migration to cope with large datasets and long running queries
* Adds `dateformat 'auto'` and `timeformat 'auto'` to cope with datasets with multiple date formats.

By adding support for a `tableNames` array, the configuration supports both single table and multi table migration.  For multi table migration, the number of tables in the source/destination need to be the same - the first table in the source is copied into the first table in the destination, etc.
```
{
  "unloadSource": {
    "clusterEndpoint": "my-source-cluster.eu-west-1.redshift.amazonaws.com",
    "clusterPort": 5439,
    "connectPwd": "my-encrypted-secret",
    "connectUser": "source_username",
    "db": "source_db",
    "schemaName": "schema_to_migrate",
    "tableNames": [
      "table1",
      "table2"
    ]
  },
  "s3Staging": {
    "aws_iam_role": "arn:aws:iam::0123456789:role/RedshiftCopyUnloadRole",
    "path": "s3://my-staging-bucket/",
    "deleteOnSuccess": "True",
    "region": "eu-west-1"
  },
  "copyTarget": {
    "clusterEndpoint": "my-destination-cluster.eu-west-1.redshift.amazonaws.com",
    "clusterPort": 5439,
    "connectPwd": "my-encrypted-secret",
    "connectUser": "destination_username",
    "db": "destination_db",
    "schemaName": "schema_to_migrate",
    "tableNames": [
      "table1",
      "table2"
    ],
    "explicit_ids": true
  }
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
