### PR TITLE
Exclude external schemas from AnalyzeVacuumUtility search path

### DIFF
--- a/src/AnalyzeVacuumUtility/lib/analyze_vacuum.py
+++ b/src/AnalyzeVacuumUtility/lib/analyze_vacuum.py
@@ -106,7 +106,7 @@ def get_pg_conn(db_host, db, db_user, db_pwd, schema_name, db_port=5439, query_g
         return None
 
     # set search paths
-    aws_utils.set_search_paths(conn, schema_name)
+    aws_utils.set_search_paths(conn, schema_name, exclude_external_schemas=True)
 
     if query_group is not None and query_group != '':
         set_query_group = 'set query_group to %s' % query_group

--- a/src/aws_utils.py
+++ b/src/aws_utils.py
@@ -45,12 +45,15 @@ def emit_metrics(cw, namespace, put_metrics):
         except:
             print('Pushing metrics to CloudWatch failed: exception %s' % sys.exc_info()[1])
 
-def set_search_paths(conn, schema_name, set_target_schema=None):
+def set_search_paths(conn, schema_name, set_target_schema=None, exclude_external_schemas=False):
     get_schemas_statement = '''
         select schema_name
         from information_schema.schemata
         where schema_name ~ '%s'
     ''' % schema_name
+
+    if exclude_external_schemas is True:
+        get_schemas_statement += " and schema_name not in (select schemaname from svv_external_schemas)"
 
     # set default search path
     search_path = 'set search_path = \'$user\',public'


### PR DESCRIPTION
*Issue #, if available:* #370 

*Description of changes:* Allow to exclude external schema when building search path. Like In VacuumAnalyzeUtility where Glue schemas can't be managed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
