### PR TITLE
scripting table ownership

### DIFF
--- a/src/AdminViews/v_generate_tbl_ddl.sql
+++ b/src/AdminViews/v_generate_tbl_ddl.sql
@@ -256,7 +256,7 @@ from (SELECT
   
   UNION
   --TABLE OWNERSHIP AS AN ALTER TABLE STATMENT
-  SELECT c.oid::bigint as table_id ,n.nspname AS schemaname, c.relname AS tablename, 600000001 AS seq, 
+  SELECT c.oid::bigint as table_id ,n.nspname AS schemaname, c.relname AS tablename, 700000000 AS seq, 
   'ALTER TABLE ' + QUOTE_IDENT(n.nspname) + '.' + QUOTE_IDENT(c.relname) + ' owner to '+  QUOTE_IDENT(u.usename) +';' AS ddl
   FROM  pg_namespace AS n
   INNER JOIN pg_class AS c ON n.oid = c.relnamespace

--- a/src/AdminViews/v_generate_tbl_ddl.sql
+++ b/src/AdminViews/v_generate_tbl_ddl.sql
@@ -256,7 +256,7 @@ from (SELECT
   
   UNION
   --TABLE OWNERSHIP AS AN ALTER TABLE STATMENT
-  SELECT c.oid::bigint as table_id ,n.nspname AS schemaname, c.relname AS tablename, 700000000 AS seq, 
+  SELECT c.oid::bigint as table_id ,n.nspname AS schemaname, c.relname AS tablename, 600500000 AS seq, 
   'ALTER TABLE ' + QUOTE_IDENT(n.nspname) + '.' + QUOTE_IDENT(c.relname) + ' owner to '+  QUOTE_IDENT(u.usename) +';' AS ddl
   FROM  pg_namespace AS n
   INNER JOIN pg_class AS c ON n.oid = c.relnamespace

--- a/src/AdminViews/v_generate_tbl_ddl.sql
+++ b/src/AdminViews/v_generate_tbl_ddl.sql
@@ -44,6 +44,7 @@ History:
 2018-01-15 pvbouwel Add QUOTE_IDENT for identifiers (schema,table and column names)
 2018-05-30 adedotua Add table_id column
 2018-05-30 adedotua Added ENCODE RAW keyword for non compressed columns (Issue #308)
+2018-10-12 dmenin Added table ownership to the script (as an alter table statment as the owner of the table is the issuer of the CREATE TABLE command)
 **********************************************************************************************/
 CREATE OR REPLACE VIEW admin.v_generate_tbl_ddl
 AS
@@ -251,7 +252,18 @@ from (SELECT
   UNION SELECT c.oid::bigint as table_id ,n.nspname AS schemaname, c.relname AS tablename, 600000000 AS seq, ';' AS ddl
   FROM  pg_namespace AS n
   INNER JOIN pg_class AS c ON n.oid = c.relnamespace
-  WHERE c.relkind = 'r' )
+  WHERE c.relkind = 'r' 
+  
+  UNION
+  --TABLE OWNERSHIP AS AN ALTER TABLE STATMENT
+  SELECT c.oid::bigint as table_id ,n.nspname AS schemaname, c.relname AS tablename, 600000001 AS seq, 
+  'ALTER TABLE ' + QUOTE_IDENT(n.nspname) + '.' + QUOTE_IDENT(c.relname) + ' owner to '+  QUOTE_IDENT(u.usename) +';' AS ddl
+  FROM  pg_namespace AS n
+  INNER JOIN pg_class AS c ON n.oid = c.relnamespace
+  INNER JOIN pg_user AS u ON c.relowner = u.usesysid
+  WHERE c.relkind = 'r'
+  
+  )
   UNION (
     SELECT c.oid::bigint as table_id,'zzzzzzzz' || n.nspname AS schemaname,
        'zzzzzzzz' || c.relname AS tablename,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Current version of the "v_generate_tbl_ddl" view does not consider the user who owns the tables. Meaning that if I run it on a database A where multiple users own tables and execute the result on table B, all the tables will be owned by the user who executed the script since the owner of an object is always the creator.

With this change I added an extra line at the end of the script (seq 600000001) that issues an alter table statement transferring the ownership of the object to the user who originally created it.

EDIT: realized that 600000001 is probably not a good idea, so change it to 600500000 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
