### PR TITLE
Correct version number in deploy function and schedule template

### DIFF
--- a/src/RedshiftAutomation/deploy-function-and-schedule.yaml
+++ b/src/RedshiftAutomation/deploy-function-and-schedule.yaml
@@ -38,7 +38,7 @@ Resources:
       Runtime: python2.7
       CodeUri:         
         Bucket: !Sub awslabs-code-${AWS::Region}
-        Key: LambdaRedshiftRunner/lambda-redshift-util-runner-1.3.zip
+        Key: LambdaRedshiftRunner/lambda-redshift-util-runner-1.4.zip
       MemorySize: 192
       Timeout: 300
       Tags:


### PR DESCRIPTION
*Description of changes:*

Use the latest version in s3 path to point to the latest lambda function code.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
