### PR TITLE
AnalyzeVacuumUtility: Fixes issue when incorrect schema was being used to generate analyze queries when .* was being passed

### DIFF
--- a/src/AnalyzeVacuumUtility/lib/analyze_vacuum.py
+++ b/src/AnalyzeVacuumUtility/lib/analyze_vacuum.py
@@ -241,7 +241,8 @@ def run_vacuum(conn,
                        + ', Unsorted_pct : ' + coalesce(unsorted :: varchar(10),'null') 
                        + ', Stats Off : ' + stats_off :: varchar(10)
                        + ' */ ;' as statement,
-                       table_name
+                       table_name,
+                       schema_name
                 FROM (SELECT schema_name,
                              table_name
                       FROM (SELECT TRIM(n.nspname) schema_name,
@@ -289,7 +290,7 @@ def run_vacuum(conn,
 
     for vs in vacuum_statements:
         statements.append(vs[0])
-        statements.append("analyze %s.\"%s\"" % (schema_name, vs[1]))
+        statements.append("analyze %s.\"%s\"" % (vs[2], vs[1]))
 
     if not run_commands(conn, statements, cw=cw, cluster_name=cluster_name, suppress_errors=ignore_errors):
         if not ignore_errors:


### PR DESCRIPTION
*Issue #, if available:*
I have not found this has been reported

*Description of changes:*
I have updated the generated SQL when that calculates the tables that require vacuuming flagged by alert. This works well when a specific schema is passed, but not with the regez to match all schemas `.*`. In this case I found it was generating invalid analyze statements where instead of creating `analyze table_schema.table_name` it was generating `.*.table_name` and thus the queries were always failing at runtime.

I have not found this issue on other cases in the script (such as when the script creates the statements to vacuum/analyze tables based on stale statistics).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
