### PR TITLE
Fix v_generate_tbl_ddl view for DISTSTYLE AUTO

### DIFF
--- a/src/AdminViews/v_generate_tbl_ddl.sql
+++ b/src/AdminViews/v_generate_tbl_ddl.sql
@@ -187,7 +187,7 @@ FROM pg_namespace AS n
    ,CASE WHEN c.reldiststyle = 0 THEN 'DISTSTYLE EVEN'
     WHEN c.reldiststyle = 1 THEN 'DISTSTYLE KEY'
     WHEN c.reldiststyle = 8 THEN 'DISTSTYLE ALL'
-    ELSE '<<Error - UNKNOWN DISTSTYLE>>'
+    ELSE 'DISTSTYLE AUTO'
     END AS ddl
   FROM pg_namespace AS n
   INNER JOIN pg_class AS c ON n.oid = c.relnamespace


### PR DESCRIPTION
*Issue #, if available:*

View returns `<<Error - UNKNOWN DISTSTYLE>>` instead of `DISTSTYLE AUTO`

*Description of changes:*

2 new values for `reldiststyle` are documented here: https://docs.aws.amazon.com/redshift/latest/dg/viewing-distribution-styles.html (10: AUTO (ALL), 11: AUTO (EVEN))
Plus, I stumbled upon an undocumented value `9` for reldiststyle, (a table that had diststyle `AUTO(EVEN)`) in Redshift version 1.0.5290.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
