### PR TITLE
Fix v_generate_tbl_ddl view for DISTSTYLE AUTO

### DIFF
--- a/src/AdminViews/v_generate_tbl_ddl.sql
+++ b/src/AdminViews/v_generate_tbl_ddl.sql
@@ -187,7 +187,7 @@ FROM pg_namespace AS n
    ,CASE WHEN c.reldiststyle = 0 THEN 'DISTSTYLE EVEN'
     WHEN c.reldiststyle = 1 THEN 'DISTSTYLE KEY'
     WHEN c.reldiststyle = 8 THEN 'DISTSTYLE ALL'
-    ELSE 'DISTSTYLE AUTO'
+    ELSE ''
     END AS ddl
   FROM pg_namespace AS n
   INNER JOIN pg_class AS c ON n.oid = c.relnamespace


### PR DESCRIPTION
*Issue #, if available:*

`DISTSTYLE ALL` results in `[Amazon](500310) Invalid operation: syntax error at or near "AUTO"`.

*Description of changes:*

Fix for bug introduced in https://github.com/awslabs/amazon-redshift-utils/pull/405, the correct syntax for automatic `DISTSTYLE` is actually nothing, not `DISTSTYLE ALL`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
