### PR TITLE
exclude external schemas in ColumnEncodingUtility

### DIFF
--- a/src/ColumnEncodingUtility/analyze-schema-compression.py
+++ b/src/ColumnEncodingUtility/analyze-schema-compression.py
@@ -197,7 +197,7 @@ def get_pg_conn():
             cleanup(conn)
             return ERROR
 
-        aws_utils.set_search_paths(conn, schema_name, target_schema)
+        aws_utils.set_search_paths(conn, schema_name, target_schema, exclude_external_schemas=True)
 
         if query_group is not None:
             set_query_group = 'set query_group to %s' % query_group


### PR DESCRIPTION
exclude external schemas in analyze-schema-compression.py using same method as analyze_vacuum.py

*Issue #, if available:*
n/a

*Description of changes:*
While using the column encoding utility, an error would be thrown if there was a common word across db and external schemas. This re-uses the functionality introduced in https://github.com/awslabs/amazon-redshift-utils/pull/371/files to apply it to analyze-schema-compression.py.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
