### PR TITLE
add missing semicolon to v_view_dependency

### DIFF
--- a/src/AdminViews/v_generate_cursor_query.sql
+++ b/src/AdminViews/v_generate_cursor_query.sql
@@ -28,4 +28,4 @@ FROM STV_ACTIVE_CURSORS cur
         AND util_text.text != 'begin;'
   JOIN PG_USER usr
     ON usr.usesysid = cur.userid
-GROUP BY cur.userid, cur.xid, cur.pid, usr.usename
+GROUP BY cur.userid, cur.xid, cur.pid, usr.usename;


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*

add missing semicolon to v_view_dependency. Since it was missing semicolon, following command to create views fails.
```bash
cat src/AdminViews/*.sql | psql -h mycluster.redshift.amazonaws.com -U admin -d admin -p 5439
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
