### PR TITLE
v_extended_table_info - adding AUTO(ALL) and AUTO(EVEN) values to size column CASE clause

### DIFF
--- a/src/AdminViews/v_extended_table_info.sql
+++ b/src/AdminViews/v_extended_table_info.sql
@@ -153,12 +153,14 @@ SELECT ti.database,
            CASE
              WHEN ("diststyle" = 'EVEN' OR "diststyle"='AUTO(EVEN)') THEN (stp.pop_slices*(colenc.cols + 3))
              WHEN SUBSTRING("diststyle",1,3) = 'KEY' THEN (stp.pop_slices*(colenc.cols + 3))
-             WHEN ("diststyle" = 'ALL'  OR "diststyle"='AUTO(ALL)') THEN (cluster_info.node_count*(colenc.cols + 3))           END 
+             WHEN ("diststyle" = 'ALL'  OR "diststyle"='AUTO(ALL)') THEN (cluster_info.node_count*(colenc.cols + 3))           
+            END 
          ELSE
            CASE
              WHEN ( "diststyle" = 'EVEN' OR "diststyle"='AUTO(EVEN)')  THEN (stp.pop_slices*(colenc.cols + 3)*2)
              WHEN SUBSTRING("diststyle",1,3) = 'KEY' THEN (stp.pop_slices*(colenc.cols + 3)*2)
-             WHEN ( "diststyle" = 'ALL' OR "diststyle"='AUTO(ALL)') THEN (cluster_info.node_count*(colenc.cols + 3)*2)           END 
+             WHEN ( "diststyle" = 'ALL' OR "diststyle"='AUTO(ALL)') THEN (cluster_info.node_count*(colenc.cols + 3)*2)           
+            END 
          END|| ' (' || ti.pct_used || ')' AS size,
          ti.tbl_rows,
          ti.unsorted,

--- a/src/AdminViews/v_extended_table_info.sql
+++ b/src/AdminViews/v_extended_table_info.sql
@@ -151,16 +151,14 @@ SELECT ti.database,
        ti.size || '/' || CASE
          WHEN stp.sum_r = stp.sum_sr OR stp.sum_sr = 0 THEN
            CASE
-             WHEN "diststyle" = 'EVEN' THEN (stp.pop_slices*(colenc.cols + 3))
+             WHEN ("diststyle" = 'EVEN' OR "diststyle"='AUTO(EVEN)') THEN (stp.pop_slices*(colenc.cols + 3))
              WHEN SUBSTRING("diststyle",1,3) = 'KEY' THEN (stp.pop_slices*(colenc.cols + 3))
-             WHEN "diststyle" = 'ALL' THEN (cluster_info.node_count*(colenc.cols + 3))
-           END 
+             WHEN ("diststyle" = 'ALL'  OR "diststyle"='AUTO(ALL)') THEN (cluster_info.node_count*(colenc.cols + 3))           END 
          ELSE
            CASE
-             WHEN "diststyle" = 'EVEN' THEN (stp.pop_slices*(colenc.cols + 3)*2)
+             WHEN ( "diststyle" = 'EVEN' OR "diststyle"='AUTO(EVEN)')  THEN (stp.pop_slices*(colenc.cols + 3)*2)
              WHEN SUBSTRING("diststyle",1,3) = 'KEY' THEN (stp.pop_slices*(colenc.cols + 3)*2)
-             WHEN "diststyle" = 'ALL' THEN (cluster_info.node_count*(colenc.cols + 3)*2)
-           END 
+             WHEN ( "diststyle" = 'ALL' OR "diststyle"='AUTO(ALL)') THEN (cluster_info.node_count*(colenc.cols + 3)*2)           END 
          END|| ' (' || ti.pct_used || ')' AS size,
          ti.tbl_rows,
          ti.unsorted,


### PR DESCRIPTION
*Issue #442*

*Description of changes:*
Adding new diststyle values in the size column calculation in v_extended_table_info.sql.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
