### PR TITLE
Fix for Issue #352

### DIFF
--- a/src/ColumnEncodingUtility/analyze-schema-compression.py
+++ b/src/ColumnEncodingUtility/analyze-schema-compression.py
@@ -764,13 +764,10 @@ def analyze(table_info):
                         comment("Adding Sortkeys: %s" % sortkeys)
                     sortkey = '%sSORTKEY(' % ('INTERLEAVED ' if has_zindex_sortkeys else '')
 
-                    for i in range(1, len(sortkeys) + 1):
-                        sortkey = sortkey + sortkeys[i]
+                    ordered_sortkey_columns = [sortkeys[index] for index in range(1, len(sortkeys) + 1)]
 
-                        if i != len(sortkeys):
-                            sortkey = sortkey + ','
-                        else:
-                            sortkey = sortkey + ')\n'
+                    sortkey += ','.join(ordered_sortkey_columns) + ')\n'
+
                     create_table = create_table + (' %s ' % sortkey)
 
                 create_table = create_table + ';'
@@ -803,8 +800,8 @@ def analyze(table_info):
                                                                             source_columns,
                                                                             schema_name,
                                                                             table_name)
-                if len(table_sortkeys) > 0:
-                    insert = "%s order by \"%s\";" % (insert, ",".join(table_sortkeys).replace(',', '\",\"'))
+                if len(ordered_sortkey_columns) > 0:
+                    insert = "%s order by \"%s\";" % (insert, ",".join(ordered_sortkey_columns).replace(',', '\",\"'))
                 else:
                     insert = "%s;" % (insert)
 


### PR DESCRIPTION
Issue  #352
https://github.com/awslabs/amazon-redshift-utils/issues/352

Changes:
- Fixed the orderby clause generated for insertion (As mentioned in the issue).
- Fixed the check for RAW encoding of first sort key. Earlier the index of the column was compared to that of the order in table sort keys, which is wrong. (Simplified the condition)
- removed the tablesortkeys, this variable had sortkeys based on the ordering of columns in the table rather than actual order of the sort keys. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
