### PR TITLE
Fix cron expression not allowing every X minutes.

### DIFF
--- a/src/RedshiftAutomation/deploy-function-and-schedule.yaml
+++ b/src/RedshiftAutomation/deploy-function-and-schedule.yaml
@@ -29,7 +29,7 @@ Parameters:
     Default: 0 0 * * ? *
     Description: Cron expression indicating how frequently to run the specified utility (default is once a day at midnight)
     Type: String
-    AllowedPattern: ^([0-5]?[0-9]|\*|\,|\-|\/) ([ 01]?[0-9]|2[0-3]|\*|\,|\-|\/) ([ 012]?[1-9]|3[01]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|\*|\,|\-|\/|\?|L|W) ([0]?[1-9]|1[0-2]|\*|\,|\-|\/) ([1-7]|MON|TUE|WED|THU|FRI|SAT|SUN|\*|\,|\-|\/|\?|L|\#) (19[7-9][0-9]|2[01][0-9][0-9]|\*|\,|\-|\/)$
+    AllowedPattern: ^([0-5]?[0-9]|\*|[0-5]?[0-9]\,[0-5]?[0-9]|[0-5]?[0-9]\-[0-5]?[0-9]|0\/[0-5]?[0-9]) ([ 01]?[0-9]|2[0-3]|\*|\,|\-|\/) ([ 012]?[1-9]|3[01]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|\*|\,|\-|\/|\?|L|W) ([0]?[1-9]|1[0-2]|\*|\,|\-|\/) ([1-7]|MON|TUE|WED|THU|FRI|SAT|SUN|\*|\,|\-|\/|\?|L|\#) (19[7-9][0-9]|2[01][0-9][0-9]|\*|\,|\-|\/)$
 Resources:
   LambdaRedshiftAutomation:
     Type: AWS::Serverless::Function

--- a/src/RedshiftAutomation/deploy-schedule.yaml
+++ b/src/RedshiftAutomation/deploy-schedule.yaml
@@ -24,7 +24,7 @@ Parameters:
     Default: 0 0 * * ? *
     Description: Cron expression indicating how frequently to run the specified utility (default is once a day at midnight)
     Type: String
-    AllowedPattern: ^([0-5]?[0-9]|\*|\,|\-|\/) ([ 01]?[0-9]|2[0-3]|\*|\,|\-|\/) ([ 012]?[1-9]|3[01]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|\*|\,|\-|\/|\?|L|W) ([0]?[1-9]|1[0-2]|\*|\,|\-|\/) ([1-7]|MON|TUE|WED|THU|FRI|SAT|SUN|\*|\,|\-|\/|\?|L|\#) (19[7-9][0-9]|2[01][0-9][0-9]|\*|\,|\-|\/)$
+    AllowedPattern: ^([0-5]?[0-9]|\*|[0-5]?[0-9]\,[0-5]?[0-9]|[0-5]?[0-9]\-[0-5]?[0-9]|0\/[0-5]?[0-9]) ([ 01]?[0-9]|2[0-3]|\*|\,|\-|\/) ([ 012]?[1-9]|3[01]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|\*|\,|\-|\/|\?|L|W) ([0]?[1-9]|1[0-2]|\*|\,|\-|\/) ([1-7]|MON|TUE|WED|THU|FRI|SAT|SUN|\*|\,|\-|\/|\?|L|\#) (19[7-9][0-9]|2[01][0-9][0-9]|\*|\,|\-|\/)$
 Resources:
   UtilityEventRule:
     Type: "AWS::Events::Rule"

--- a/src/RedshiftAutomation/deploy.yaml
+++ b/src/RedshiftAutomation/deploy.yaml
@@ -60,32 +60,32 @@ Parameters:
     Default: 0 0 * * ? *
     Description: Cron expression for when to run the Column Encoding Utility (default midnight daily)
     Type: String
-    AllowedPattern: ^([0-5]?[0-9]|\*|\,|\-|\/) ([ 01]?[0-9]|2[0-3]|\*|\,|\-|\/) ([ 012]?[1-9]|3[01]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|\*|\,|\-|\/|\?|L|W) ([0]?[1-9]|1[0-2]|\*|\,|\-|\/) ([1-7]|MON|TUE|WED|THU|FRI|SAT|SUN|\*|\,|\-|\/|\?|L|\#) (19[7-9][0-9]|2[01][0-9][0-9]|\*|\,|\-|\/)$
+    AllowedPattern: ^([0-5]?[0-9]|\*|[0-5]?[0-9]\,[0-5]?[0-9]|[0-5]?[0-9]\-[0-5]?[0-9]|0\/[0-5]?[0-9]) ([ 01]?[0-9]|2[0-3]|\*|\,|\-|\/) ([ 012]?[1-9]|3[01]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|\*|\,|\-|\/|\?|L|W) ([0]?[1-9]|1[0-2]|\*|\,|\-|\/) ([1-7]|MON|TUE|WED|THU|FRI|SAT|SUN|\*|\,|\-|\/|\?|L|\#) (19[7-9][0-9]|2[01][0-9][0-9]|\*|\,|\-|\/)$
   AnalyzeCronExpression:
     Default: 0 1 * * ? *
     Description: Cron expression for when to run the Analyze  Utility (default 1 am daily)
     Type: String
-    AllowedPattern: ^([0-5]?[0-9]|\*|\,|\-|\/) ([ 01]?[0-9]|2[0-3]|\*|\,|\-|\/) ([ 012]?[1-9]|3[01]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|\*|\,|\-|\/|\?|L|W) ([0]?[1-9]|1[0-2]|\*|\,|\-|\/) ([1-7]|MON|TUE|WED|THU|FRI|SAT|SUN|\*|\,|\-|\/|\?|L|\#) (19[7-9][0-9]|2[01][0-9][0-9]|\*|\,|\-|\/)$
+    AllowedPattern: ^([0-5]?[0-9]|\*|[0-5]?[0-9]\,[0-5]?[0-9]|[0-5]?[0-9]\-[0-5]?[0-9]|0\/[0-5]?[0-9]) ([ 01]?[0-9]|2[0-3]|\*|\,|\-|\/) ([ 012]?[1-9]|3[01]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|\*|\,|\-|\/|\?|L|W) ([0]?[1-9]|1[0-2]|\*|\,|\-|\/) ([1-7]|MON|TUE|WED|THU|FRI|SAT|SUN|\*|\,|\-|\/|\?|L|\#) (19[7-9][0-9]|2[01][0-9][0-9]|\*|\,|\-|\/)$
   VacuumCronExpression:
     Default: 0 2 * * ? *
     Description: Cron expression for when to run the Vacuum Utility (default 2 am daily)
     Type: String
-    AllowedPattern: ^([0-5]?[0-9]|\*|\,|\-|\/) ([ 01]?[0-9]|2[0-3]|\*|\,|\-|\/) ([ 012]?[1-9]|3[01]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|\*|\,|\-|\/|\?|L|W) ([0]?[1-9]|1[0-2]|\*|\,|\-|\/) ([1-7]|MON|TUE|WED|THU|FRI|SAT|SUN|\*|\,|\-|\/|\?|L|\#) (19[7-9][0-9]|2[01][0-9][0-9]|\*|\,|\-|\/)$
+    AllowedPattern: ^([0-5]?[0-9]|\*|[0-5]?[0-9]\,[0-5]?[0-9]|[0-5]?[0-9]\-[0-5]?[0-9]|0\/[0-5]?[0-9]) ([ 01]?[0-9]|2[0-3]|\*|\,|\-|\/) ([ 012]?[1-9]|3[01]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|\*|\,|\-|\/|\?|L|W) ([0]?[1-9]|1[0-2]|\*|\,|\-|\/) ([1-7]|MON|TUE|WED|THU|FRI|SAT|SUN|\*|\,|\-|\/|\?|L|\#) (19[7-9][0-9]|2[01][0-9][0-9]|\*|\,|\-|\/)$
   MonitorCronExpression:
     Default: 5 * * * ? *
     Description: Cron expression for when to run Monitoring (default 5 minutes past every hour)
     Type: String
-    AllowedPattern: ^([0-5]?[0-9]|\*|\,|\-|\/) ([ 01]?[0-9]|2[0-3]|\*|\,|\-|\/) ([ 012]?[1-9]|3[01]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|\*|\,|\-|\/|\?|L|W) ([0]?[1-9]|1[0-2]|\*|\,|\-|\/) ([1-7]|MON|TUE|WED|THU|FRI|SAT|SUN|\*|\,|\-|\/|\?|L|\#) (19[7-9][0-9]|2[01][0-9][0-9]|\*|\,|\-|\/)$
+    AllowedPattern: ^([0-5]?[0-9]|\*|[0-5]?[0-9]\,[0-5]?[0-9]|[0-5]?[0-9]\-[0-5]?[0-9]|0\/[0-5]?[0-9]) ([ 01]?[0-9]|2[0-3]|\*|\,|\-|\/) ([ 012]?[1-9]|3[01]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|\*|\,|\-|\/|\?|L|W) ([0]?[1-9]|1[0-2]|\*|\,|\-|\/) ([1-7]|MON|TUE|WED|THU|FRI|SAT|SUN|\*|\,|\-|\/|\?|L|\#) (19[7-9][0-9]|2[01][0-9][0-9]|\*|\,|\-|\/)$
   SysTablesCronExpression:
     Default: 0 0 * * ? *
     Description: Cron expression for when to run System Table Persistence (nightly at midnight)
     Type: String
-    AllowedPattern: ^([0-5]?[0-9]|\*|\,|\-|\/) ([ 01]?[0-9]|2[0-3]|\*|\,|\-|\/) ([ 012]?[1-9]|3[01]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|\*|\,|\-|\/|\?|L|W) ([0]?[1-9]|1[0-2]|\*|\,|\-|\/) ([1-7]|MON|TUE|WED|THU|FRI|SAT|SUN|\*|\,|\-|\/|\?|L|\#) (19[7-9][0-9]|2[01][0-9][0-9]|\*|\,|\-|\/)$
+    AllowedPattern: ^([0-5]?[0-9]|\*|[0-5]?[0-9]\,[0-5]?[0-9]|[0-5]?[0-9]\-[0-5]?[0-9]|0\/[0-5]?[0-9]) ([ 01]?[0-9]|2[0-3]|\*|\,|\-|\/) ([ 012]?[1-9]|3[01]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|\*|\,|\-|\/|\?|L|W) ([0]?[1-9]|1[0-2]|\*|\,|\-|\/) ([1-7]|MON|TUE|WED|THU|FRI|SAT|SUN|\*|\,|\-|\/|\?|L|\#) (19[7-9][0-9]|2[01][0-9][0-9]|\*|\,|\-|\/)$
   WlmSchedulerCronExpression:
     Default: 2 * * * ? *
     Description: Cron expression for when to run the WLM Scheduler Daemon (2 minutes past every hour)
     Type: String
-    AllowedPattern: ^([0-5]?[0-9]|\*|\,|\-|\/) ([ 01]?[0-9]|2[0-3]|\*|\,|\-|\/) ([ 012]?[1-9]|3[01]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|\*|\,|\-|\/|\?|L|W) ([0]?[1-9]|1[0-2]|\*|\,|\-|\/) ([1-7]|MON|TUE|WED|THU|FRI|SAT|SUN|\*|\,|\-|\/|\?|L|\#) (19[7-9][0-9]|2[01][0-9][0-9]|\*|\,|\-|\/)$
+    AllowedPattern: ^([0-5]?[0-9]|\*|[0-5]?[0-9]\,[0-5]?[0-9]|[0-5]?[0-9]\-[0-5]?[0-9]|0\/[0-5]?[0-9]) ([ 01]?[0-9]|2[0-3]|\*|\,|\-|\/) ([ 012]?[1-9]|3[01]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|\*|\,|\-|\/|\?|L|W) ([0]?[1-9]|1[0-2]|\*|\,|\-|\/) ([1-7]|MON|TUE|WED|THU|FRI|SAT|SUN|\*|\,|\-|\/|\?|L|\#) (19[7-9][0-9]|2[01][0-9][0-9]|\*|\,|\-|\/)$
   WlmSchedulerConfigLocation:
     Default: s3://mybucket/prefix/config.json
     Description: Configuration File Location for the WLM Scheduler


### PR DESCRIPTION
*Issue #, if available:*
None, that I could find.

*Description of changes:*
You can't currently deploy these CF stacks with `0/15 * * * ? *` or `0,30 * * * ? *` cron syntax. I added the ability to do that by replacing the existing cron syntax in all of them with a cron that will allow for all of these.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
