### PR TITLE
Fix for issue #441:  IndexError in run_vacuum() in analyze_vacuum.py

### DIFF
--- a/src/AnalyzeVacuumUtility/lib/analyze_vacuum.py
+++ b/src/AnalyzeVacuumUtility/lib/analyze_vacuum.py
@@ -204,7 +204,8 @@ def run_vacuum(conn,
                                          + ', Unsorted_pct : ' + coalesce(unsorted :: varchar(10),'null') 
                                          + ', Stats Off : ' + stats_off :: varchar(10)
                                          + ' */ ;' as statement,
-                                         "table" as table_name
+                                         "table" as table_name,
+                                         "schema" as schema_name
                                   FROM svv_table_info
                                   WHERE (unsorted > %s or stats_off > %s)
                                     AND   size < %s
@@ -221,7 +222,8 @@ def run_vacuum(conn,
                                          + ', Unsorted_pct : ' + coalesce(unsorted :: varchar(10),'null')
                                          + ', Stats Off : ' + stats_off :: varchar(10)
                                          + ' */ ;' as statement,
-                                         "table" as table_name
+                                         "table" as table_name,
+                                         "schema" as schema_name
                                   FROM svv_table_info
                                   WHERE (unsorted > %s or stats_off > %s)
                                     AND   size < %s


### PR DESCRIPTION
fixed IndexError in run_vacuum() in analyze_vacuum.py

*Issue #, if available:* 441

*Description of changes:* 
get_vacuum_statement when passed in 

vacuum_statements = execute_query(conn, get_vacuum_statement) ,

returns only **two columns**, where as ,

 for vs in vacuum_statements:
            statements.append(vs[0])
            statements.append("analyze %s.\"%s\"" % (vs[2], vs[1]))

**expects three columns** vs[0], vs[1] and vs[2].

Thus get_vacuum_statement is modified to fix the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
