### PR TITLE
Replacing CASE statements with TO_CHAR: 'Day' and 'Month'

### DIFF
--- a/src/AdminScripts/generate_calendar.sql
+++ b/src/AdminScripts/generate_calendar.sql
@@ -44,29 +44,8 @@ SELECT
  DATE_PART('day', date_gen.dt)::smallint AS "day",
  DATE_PART('qtr', date_gen.dt)::smallint AS "quarter",
  DATE_PART('w', date_gen.dt)::smallint AS "week",
- CASE DATE_PART('dow', date_gen.dt)
-  WHEN 0 THEN 'Sunday'
-  WHEN 1 THEN 'Monday'
-  WHEN 2 THEN 'Tuesday'
-  WHEN 3 THEN 'Wednesday'
-  WHEN 4 THEN 'Thursday'
-  WHEN 5 THEN 'Friday'
-  WHEN 6 THEN 'Saturday'
- END::VARCHAR(9) AS "day_name",
- CASE DATE_PART('mon', date_gen.dt)::smallint
-  WHEN 1 THEN 'January'
-  WHEN 2 THEN 'February'
-  WHEN 3 THEN 'March'
-  WHEN 4 THEN 'April'
-  WHEN 5 THEN 'May'
-  WHEN 6 THEN 'June'
-  WHEN 7 THEN 'July'
-  WHEN 8 THEN 'August'
-  WHEN 9 THEN 'September'
-  WHEN 10 THEN 'October'
-  WHEN 11 THEN 'November'
-  WHEN 12 THEN 'December'
- END::VARCHAR(9) AS "month_name",
+ TO_CHAR(date_gen.dt, 'Day')::VARCHAR(9) AS "day_name",
+ TO_CHAR(date_gen.dt, 'Month')::VARCHAR(9) AS "month_name",
  f_holiday(date_gen.dt)::boolean AS "holiday_flag",
  CASE  
   WHEN DATE_PART('dow', date_gen.dt)::smallint IN (0,6) THEN TRUE


### PR DESCRIPTION
Replaced
```
CASE DATE_PART('dow', date_gen.dt)
  WHEN 0 THEN 'Sunday'
  WHEN 1 THEN 'Monday'
  WHEN 2 THEN 'Tuesday'
  WHEN 3 THEN 'Wednesday'
  WHEN 4 THEN 'Thursday'
  WHEN 5 THEN 'Friday'
  WHEN 6 THEN 'Saturday'
 END::VARCHAR(9) AS "day_name",
 CASE DATE_PART('mon', date_gen.dt)::smallint
  WHEN 1 THEN 'January'
  WHEN 2 THEN 'February'
  WHEN 3 THEN 'March'
  WHEN 4 THEN 'April'
  WHEN 5 THEN 'May'
  WHEN 6 THEN 'June'
  WHEN 7 THEN 'July'
  WHEN 8 THEN 'August'
  WHEN 9 THEN 'September'
  WHEN 10 THEN 'October'
  WHEN 11 THEN 'November'
  WHEN 12 THEN 'December'
 END::VARCHAR(9) AS "month_name",
```
with
```
 TO_CHAR(date_gen.dt, 'Day')::VARCHAR(9) AS "day_name",
 TO_CHAR(date_gen.dt, 'Month')::VARCHAR(9) AS "month_name",
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
