### PR TITLE
python 3.5+ syntax fixes plus fixed strong warnings (unbound variables)

### DIFF
--- a/src/MultipleTableRestoreUtility/multitablerestore.py
+++ b/src/MultipleTableRestoreUtility/multitablerestore.py
@@ -21,6 +21,7 @@ Managed by adedotua
 2017-12-23: Added cosmetic changes. Logs will now record timestamp for each step. 
             Number of successful, canceled or Failed restores will now be recorded once script completes
 2017-12-23: Fixed issue where script would get stuck if table restore status is in state CANCELED.
+2020-05-08: Python3 3.5+
 """
 
 import json
@@ -58,7 +59,7 @@ class RsRestore:
                                                                                TargetSchemaName=self.tgtSchema,
                                                                                NewTableName=tgtTable)
         except ClientError as e:
-            print e.response['Error']['Message']
+            print(e.response['Error']['Message'])
             exit()
 
     # Get the status of the table restore
@@ -74,13 +75,13 @@ class RsRestore:
     def printmessage(self, status):
         datetime_str = str(datetime.datetime.now())
         if status == 'FAILED':
-            print "[%s] %s " % (datetime_str, self.restorestatus('Message'))
+            print("[%s] %s " % (datetime_str, self.restorestatus('Message')))
         elif status != 'SUCCEEDED':
-            print "[%s] STATUS: %s " % (datetime_str, self.restorestatus('Status'))
+            print("[%s] STATUS: %s " % (datetime_str, self.restorestatus('Status')))
         else:
-            print "[%s] DETAIL: Table %s.%s restored to database %s. Total size restored is %sMB." \
-                  % (datetime_str, self.restorestatus('TargetSchemaName'), self.restorestatus('NewTableName'),
-                     self.restorestatus('TargetDatabaseName'), self.restorestatus('TotalDataInMegaBytes'))
+            print("[%s] DETAIL: Table %s.%s restored to database %s. Total size restored is %sMB." \
+             % (datetime_str, self.restorestatus('TargetSchemaName'), self.restorestatus('NewTableName'),
+                     self.restorestatus('TargetDatabaseName'), self.restorestatus('TotalDataInMegaBytes')))
 
 
 #  Usage of script
@@ -88,7 +89,7 @@ def errormsg(script_name):
     print("Usage: %s --target-database-name <target database> "
           "--source-database-name <source database> "
           "--snapshot-identifier <snapshot name> "
-          "--cluster-identifier <cluster> --listfile <filename>") % script_name
+          "--cluster-identifier <cluster> --listfile <filename>" % script_name)
 
 
 #  Table restore function that can be called from within another module
@@ -99,15 +100,15 @@ def tablerestore(tgtdbname, srcdbname, snapshotid, clusterid, filename):
             datac = json.load(data_file)
             #  Check json for valid key
             if 'TableRestoreList' not in datac:
-                print 'ERROR: \'%s\' key in %s list is an invalid key. Valid key is \'TableRestoreList\'.' \
-                      % (datac.keys()[0], filename)
+                print('ERROR: \'%s\' key in %s list is an invalid key. Valid key is \'TableRestoreList\'.' \
+                 % (datac.keys()[0], filename))
                 exit()
     #  Check restore list file exists
     except IOError:
-        print 'Table restore list %s does not exist. Check file and try again.' % filename
+        print('Table restore list %s does not exist. Check file and try again.' % filename)
         exit()
     except Exception as e:
-        print e
+        print(e)
         exit()
 
     count_succeeded = 0
@@ -116,22 +117,25 @@ def tablerestore(tgtdbname, srcdbname, snapshotid, clusterid, filename):
     count_unknown = 0
     total_restore_size = 0
 
+    srcschema = None
+    srctable = None
+
     for i in datac['TableRestoreList']:
         try:
             srcschema = i['Schemaname']
             srctable = i['Tablename']
         except KeyError as e:
-            print 'ERROR: Expected key %s is missing in %s.' % (e, filename)
-            print 'DETAIL: %s' % i
+            print('ERROR: Expected key %s is missing in %s.' % (e, filename))
+            print('DETAIL: %s' % i)
             exit()
         tgtschema = srcschema
         trgttable = srctable
         tlr = RsRestore(clusterid, snapshotid, srcdbname, srcschema, tgtdbname, tgtschema)
         tlr.restoretable(srctable, trgttable)
-        print "%s Starting Table Restores %s" % ('-' * 50, '-' * 50)
-        print "[%s] Requestid: %s " % (str(datetime.datetime.now()), tlr.restorestatus('TableRestoreRequestId'))
-        print "[%s] INFO: Starting restore of %s to schema %s in database %s" % (str(datetime.datetime.now()),
-                                                                                 trgttable, tgtschema, tgtdbname)
+        print("%s Starting Table Restores %s" % ('-' * 50, '-' * 50))
+        print("[%s] Requestid: %s " % (str(datetime.datetime.now()), tlr.restorestatus('TableRestoreRequestId')))
+        print("[%s] INFO: Starting restore of %s to schema %s in database %s" % (str(datetime.datetime.now()),
+                                                                                 trgttable, tgtschema, tgtdbname))
         current_status = tlr.restorestatus('Status')
         while current_status != 'SUCCEEDED' and current_status != 'FAILED' and current_status != 'CANCELED':
             if current_status != previous_status:
@@ -150,11 +154,11 @@ def tablerestore(tgtdbname, srcdbname, snapshotid, clusterid, filename):
         else:
             count_unknown += 1
         tlr.printmessage(current_status)
-    print "%s Table Restore Summary %s" % ('-' * 51, '-' * 51)
-    print "[%s] Succeeded: %d Failed: %d Canceled: %d Unknown: %d Total Size: %dMB" \
+    print("%s Table Restore Summary %s" % ('-' * 51, '-' * 51))
+    print("[%s] Succeeded: %d Failed: %d Canceled: %d Unknown: %d Total Size: %dMB" \
           % (str(datetime.datetime.now()), count_succeeded, count_failed, count_canceled,
-             count_unknown, total_restore_size)
-    print "%s" % ('-' * 125)
+             count_unknown, total_restore_size))
+    print("%s" % ('-' * 125))
 
 
 def main(input_args):
@@ -163,13 +167,14 @@ def main(input_args):
     snapshotid = None
     clusterid = None
     filename = None
+    optlist = None
 
     try:
         optlist,  remaining = getopt.getopt(input_args[1:], "", ['target-database-name=', 'source-database-name=',
                                                                  'snapshot-identifier=', 'cluster-identifier=',
                                                                  'listfile='])
     except getopt.GetoptError as err:
-        print str(err)
+        print(str(err))
         exit()
 
     for arg,  value in optlist:
@@ -184,7 +189,7 @@ def main(input_args):
         elif arg == "--listfile":
             filename = value
         else:
-            print "Unknown argument %s" % arg
+            print("Unknown argument %s" % arg)
     if (tgtdbname is None) or (srcdbname is None) or (snapshotid is None) or (clusterid is None) or (filename is None):
         errormsg(input_args[0])
         exit()


### PR DESCRIPTION
*Issue #, if available:*
specifically addressing Python3 syntax in MultipleTableRestoreUtility, issue mentioned partially in #144

*Description of changes:*
python 3.5+ syntax fixes plus fixed strong warnings (unbound variables)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
