### PR TITLE
bugfix for procedure names in `v_generate_user_grant_revoke_ddl.sql`

### DIFF
--- a/src/AdminViews/v_generate_user_grant_revoke_ddl.sql
+++ b/src/AdminViews/v_generate_user_grant_revoke_ddl.sql
@@ -71,7 +71,7 @@ SELECT objowner,
 	translate(trim(split_part(aclstring,'/',2)),'"','')::text AS grantor, 
 	trim(split_part(split_part(aclstring,'=',2),'/',1))::text AS privilege, 
 	CASE WHEN objtype = 'default acl' THEN objname 
-		WHEN objtype in ('procedure','function') AND regexp_instr(schemaname,'[^a-z]') > 0 THEN objname
+		WHEN objtype in ('procedure','function') AND regexp_instr(objname, schemaname) > 0 THEN objname
 		WHEN objtype in ('procedure','function','column') THEN QUOTE_IDENT(schemaname)||'.'||objname 
 		ELSE nvl(QUOTE_IDENT(schemaname)||'.'||QUOTE_IDENT(objname),QUOTE_IDENT(objname)) END::text as fullobjname,
 	CASE WHEN split_part(aclstring,'=',1)='' THEN 'PUBLIC' 


### PR DESCRIPTION
procedure names contain the schema name so it turns into `schema.schema.proc` instead of `schema.proc`

*Issue #, if available:*
procedure names contain the schema name so it turns into `schema.schema.proc` instead of `schema.proc`

*Description of changes:*
fix the regex lookup.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
