### PR TITLE
Update 'Enc' on table_info.sql

### DIFF
--- a/src/AdminScripts/table_info.sql
+++ b/src/AdminScripts/table_info.sql
@@ -21,6 +21,7 @@ History:
 2015-02-16 ericfe created
 2017-03-23 thiyagu Added percentage encoded column metric (pct_enc) and fixes  
 2017-10-01 mscaer Fixed columns "rows", pct_stats_off, and pct_unsorted to be correct for DISTSTYLE ALL.
+2021-03-05 edsonune Fixed column "Enc" to correctly show values for non-compressed tables.
 **********************************************************************************************/
 
 SELECT TRIM(pgn.nspname) AS SCHEMA,
@@ -74,7 +75,7 @@ FROM (SELECT db_id,
                      MIN(CASE attisdistkey WHEN 't' THEN attname ELSE NULL END) AS "distkey",
                      MIN(CASE attsortkeyord WHEN 1 THEN attname ELSE NULL END) AS head_sort,
                      MAX(attsortkeyord) AS n_sortkeys,
-                     MAX(attencodingtype) AS max_enc,
+                     MAX(case when attencodingtype not in (0,128) THEN attencodingtype ELSE 0 END) AS max_enc,
                      SUM(case when attencodingtype <> 0 then 1 else 0 end)::DECIMAL(20,3)/COUNT(attencodingtype)::DECIMAL(20,3)  *100.00 as pct_enc
               FROM pg_attribute
               GROUP BY 1) AS det ON det.attrelid = a.id


### PR DESCRIPTION
I did a few tests using the script here - https://github.com/awslabs/amazon-redshift-utils/blob/master/src/AdminScripts/table_info.sql , and I just noticed an issue with  column "Enc" (which is Y if the table has at least one compressed column, N otherwise)

When I test:

create table test_1_comp(
id int encode raw,  -- no compression
val varchar(20) encode raw  -- no compression
);
create table test_2_comp(
id int encode raw,  -- no compression
val varchar(20) encode lzo
);
create table test_3_comp(
id int encode lzo,
val varchar(20) encode lzo
);
insert into test_1_comp values (1,'one'),(2,'two'),(3,'three');
insert into test_2_comp values (1,'one'),(2,'two'),(3,'three');
insert into test_3_comp values (1,'one'),(2,'two'),(3,'three');

and then query https://docs.amazonaws.cn/en_us/redshift/latest/dg/r_SVV_TABLE_INFO.html
I get the expected result for encoded:
 test_1_comp - Enc N
 test_2_comp - Enc Y
 test_3_comp - Enc Y  

However, https://github.com/awslabs/amazon-redshift-utils/blob/master/src/AdminScripts/table_info.sql , returns Y to all

Where:

Enc comes from:
decode(det.max_enc,
             0,'N',
             'Y'
       ) AS Enc,

which takes the value from det.max_enc:
(SELECT attrelid,
                     MIN(CASE attisdistkey WHEN 't' THEN attname ELSE NULL END) AS "distkey",
                     MIN(CASE attsortkeyord WHEN 1 THEN attname ELSE NULL END) AS head_sort,
                     MAX(attsortkeyord) AS n_sortkeys,
                     MAX(attencodingtype) AS max_enc,
                     SUM(case when attencodingtype <> 0 then 1 else 0 end)::DECIMAL(20,3)/COUNT(attencodingtype)::DECIMAL(20,3)  *100.00 as pct_enc
              FROM pg_attribute
              GROUP BY 1) AS det  

And it  has a "MAX(attencodingtype) AS max_enc," assuming that "no encoding" will be represented by zero '0', and therefore any value > 0 would mean it is encoded

But I did check with the following query using the tables I've created, and "no encoding" (shown as  'none') can be represented either by '0' or '128':

              SELECT attrelid,
                     MIN(CASE attisdistkey WHEN 't' THEN attname ELSE NULL END) AS "distkey",
                     MIN(CASE attsortkeyord WHEN 1 THEN attname ELSE NULL END) AS head_sort,
                     MAX(attsortkeyord) AS n_sortkeys,
                     attencodingtype AS max_enc,
                     format_encoding(attencodingtype) attencoding,
                     SUM(case when attencodingtype <> 0 then 1 else 0 end)::DECIMAL(20,3)/COUNT(attencodingtype)::DECIMAL(20,3)  *100.00 as pct_enc
              FROM pg_attribute
              WHERE attrelid in ('101548','101552','101550')
              GROUP BY 1,5,6
              ORDER BY 1
 
That being said, MAX(attencodingtype) > 0 would not actually mean it is encoded, as we seem to assume.

If that is the case, a way to fix would be to replace:
MAX(attencodingtype) AS max_enc

with:
MAX(case when attencodingtype not in (0,128) THEN attencodingtype ELSE 0 END) AS max_enc

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
