### PR TITLE
feat: Add view v_view_table_column_dependency

### DIFF
--- a/src/AdminViews/README.md
+++ b/src/AdminViews/README.md
@@ -39,4 +39,5 @@ All views assume you have a schema called admin.
 | v\_open\_session.sql |   View to monitor currently connected and disconnected sessions | 
 | v\_session\_leakage\_by\_cnt.sql |   View to monitor session leakage by remote host |   
 | v\_space\_used\_per\_tbl.sql |   View to get pull space used per table | 
-| v\_view\_dependency.sql |   View to get the names of the views that are dependent other tables/views |
+| v\_view\_dependency.sql |   View to get the names of the views that are dependent on other tables/views |
+| v\_view\_table\_column\_dependency.sql | View to get the views that are dependent on specific columns |

--- a/src/AdminViews/v_view_table_column_dependency.sql
+++ b/src/AdminViews/v_view_table_column_dependency.sql
@@ -1,0 +1,29 @@
+--DROP VIEW admin.v_view_table_column_dependency;
+/*************************************************************
+Purpose: View to get the the views that depend on specific
+    columns to migrate them away from using this column. 
+
+Usage: To find views depending on 'my_col' of table 'my_tbl'
+       SELECT * FROM admin.v_view_table_column_dependency
+       WHERE tablename='my_tbl' AND columnname='my_col';
+
+History:
+2021-04-27 pvbouwel Created
+*************************************************************/
+CREATE OR REPLACE VIEW admin.v_view_table_column_dependency
+AS
+SELECT
+  pc1.relname AS viewname
+  , pc2.relname AS tablename
+  , pa.attname AS columnname
+FROM pg_depend pd
+JOIN pg_rewrite rw ON rw.oid = pd.objid
+JOIN pg_class pc1 ON pc1.oid = rw.ev_class
+JOIN pg_class pc2 ON pc2.oid = pd.refobjid
+JOIN pg_attribute pa ON pa.attrelid = pd.refobjid
+  AND pa.attnum = pd.refobjsubid
+  AND pa.attnum>0 -- Only user columns
+WHERE classid=(SELECT oid FROM pg_class WHERE relname='pg_rewrite') -- dependency from rewriter rule
+  AND refclassid=(SELECT oid FROM pg_class WHERE relname='pg_class') -- dependency on a relation
+  AND pc2.relowner > 1 -- Only dependencies on non-system relations
+;


### PR DESCRIPTION
Add a view to get the the views that depend on specific columns.
This is useful when you have columns from which you want to migrate away.
For example after creating new columns with more efficient datatypes.

Views depending on the old column can be easily identified using this
view and thus allows the DBA to rewrite them to benefit the workload
by using more efficient new columns.

Tested on Redshift version 1.0.25813.

*Issue #, if available:* N/A

*Description of changes:* Added the view described. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
