### PR TITLE
Add support for materialized views in v_generate_view_ddl

### DIFF
--- a/src/AdminViews/v_generate_view_ddl.sql
+++ b/src/AdminViews/v_generate_view_ddl.sql
@@ -5,16 +5,26 @@ History:
 2014-02-10 jjschmit Created
 2018-01-15 pvbouwel Replace tabs and add QUOTE_IDENT for identifiers (schema and view names)
 2018-08-03 alexlsts Included CASE to check for late binding view 
+2021-04-23 pvbouwel Replace logic to identify different cases to support materialized views.
 **********************************************************************************************/
 CREATE OR REPLACE VIEW admin.v_generate_view_ddl
 AS
 SELECT 
     n.nspname AS schemaname
     ,c.relname AS viewname
-    ,'--DROP VIEW ' + QUOTE_IDENT(n.nspname) + '.' + QUOTE_IDENT(c.relname) + ';\n'
-    + CASE 
-     	WHEN c.relnatts > 0 then 'CREATE OR REPLACE VIEW ' + QUOTE_IDENT(n.nspname) + '.' + QUOTE_IDENT(c.relname) + ' AS\n' + COALESCE(pg_get_viewdef(c.oid, TRUE), '')
-     	ELSE  COALESCE(pg_get_viewdef(c.oid, TRUE), '') END AS ddl
+    ,'--DROP '
+    ||  
+    CASE STRPOS(LOWER(pg_get_viewdef(c.oid, TRUE)), 'materialized')
+      WHEN 8 THEN 'MATERIALIZED '::text --CREATE MATERIALIZED would be the start
+      ELSE ''::text
+    END 
+    ||
+    'VIEW ' + QUOTE_IDENT(n.nspname) + '.' + QUOTE_IDENT(c.relname) + ';\n'
+    + CASE STRPOS(LOWER(pg_get_viewdef(c.oid, TRUE)), 'create')
+        WHEN 1 then '' -- CREATE statement already present
+     	ELSE           --no CREATE statement present so no materialized view anyway
+          'CREATE OR REPLACE VIEW ' + QUOTE_IDENT(n.nspname) + '.' + QUOTE_IDENT(c.relname) + ' AS\n'
+      END || COALESCE(pg_get_viewdef(c.oid, TRUE), '') AS ddl
 FROM 
     pg_catalog.pg_class AS c
 INNER JOIN


### PR DESCRIPTION
Materialized views cannot be dropped using `DROP VIEW` but instead
need to use `DROP MATERIALIZED VIEW` this change will make sure that
the `DROP` in the comment is appropriately changed.

The provided DDL is also fixed; prior to this change the DDL was
preceded with a `CREATE OR REPLACE VIEW <schemaname>.<viewname>`.
This change will generate correct DDL.

To do this we check the generated view definition with exact positions
for the keywords since those keywords could be part of the view
definition itself.

This new version has been tested with the following views:
 - regular view
 - late binding view
 - materialized view

*Issue #, if available:*
 - Issue #551 for support of Materialized views would be covered by this.
 - Issue #340 was already fixed in the past this new version has also been tested with a late binding view so that issue can be resolved as well

*Description of changes:*

The SQL checks the result of `pg_get_viewdef` in order to handle different cases correctly. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
