### PR TITLE
Add support for postgresql NAME type in v_generate_tbl_ddl

### DIFF
--- a/src/AdminViews/v_generate_tbl_ddl.sql
+++ b/src/AdminViews/v_generate_tbl_ddl.sql
@@ -112,6 +112,8 @@ FROM
       THEN REPLACE(UPPER(format_type(a.atttypid, a.atttypmod)), 'CHARACTER VARYING', 'VARCHAR')
      WHEN STRPOS(UPPER(format_type(a.atttypid, a.atttypmod)), 'CHARACTER') > 0
       THEN REPLACE(UPPER(format_type(a.atttypid, a.atttypmod)), 'CHARACTER', 'CHAR')
+     WHEN STRPOS(UPPER(format_type(a.atttypid, a.atttypmod)), 'NAME') > 0
+      THEN REPLACE(UPPER(format_type(a.atttypid, a.atttypmod)), 'NAME', 'VARCHAR(63)')
      ELSE UPPER(format_type(a.atttypid, a.atttypmod))
      END AS col_datatype
     ,CASE WHEN format_encoding((a.attencodingtype)::integer) = 'none'


### PR DESCRIPTION
Replacing NAME with a 63 byte varchar, since it is an unsupported postgresql type

*Description of changes:*
In src/AdminViews/v_generate_tbl_ddl.sql (lines 115 & 116)

I used the query in the view to generate table ddl for an automated redshift db migration, but upon executing the queries to replicate the schema on another cluster, I came across: ERROR: Column <column_name>  has unsupported type "name"

The issue had a rather simple solution, which was adding lines 115 & 116 to replace instances of the NAME type with a 63 byte varchar, which is what name is regardless.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
