### PR TITLE
updating auth method from access & secret key  to iam_role in copy commands

### DIFF
--- a/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCDS/100TB/ddl.sql
+++ b/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCDS/100TB/ddl.sql
@@ -552,42 +552,48 @@ ss_sold_date_sk int4 ,
 ) distkey(ss_item_sk) sortkey(ss_sold_date_sk);
 
 /*
-	To load the sample data, you must provide authentication for your cluster to access Amazon S3 on your behalf.
-	You can provide either role-based authentication or key-based authentication.
-
+/*
 	Text files needed to load test data under s3://redshift-downloads/TPC-DS/2.13/100TB are publicly available.
-	Any valid credentials should have read access.
+	
+  To load the sample data, you must provide authentication for your cluster to access Amazon S3 on your behalf.
 
-	The COPY commands include a placeholder for the aws_access_key_id and aws_secret_access_key.
-	User must update the credentials clause below with valid credentials or the command will fail.
+  You can provide authentication by referencing an IAM role that you have created. You can set an IAM_Role as the default for your cluster or you can directly provide the ARN of an IAM_Role.  
+  For more information https://docs.aws.amazon.com/redshift/latest/mgmt/authorizing-redshift-service.html
 
-	For more information check samples in https://docs.aws.amazon.com/redshift/latest/gsg/rs-gsg-create-sample-db.html
+  The COPY commands include a placeholder for IAM_Role, in this code IAM_Role clause is set to use the default IAM_Role. If your cluster does not have a IAM_Role set as default then please follow the instructions provided here:
+
+  https://docs.aws.amazon.com/redshift/latest/mgmt/default-iam-role.html
+
+  For more information check samples in https://docs.aws.amazon.com/redshift/latest/gsg/rs-gsg-create-sample-db.html
+
+  **Note** another option to provide IAM_Role is to provide IAM_Role ARN in IAM_Role clause. For example
+  copy call_center from 's3://redshift-downloads/TPC-DS/2.13/100TB/call_center/' IAM_Role 'Replace text inside the quotes with Redshift cluster IAM_Role ARN' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
 */
 
-copy call_center from 's3://redshift-downloads/TPC-DS/2.13/100TB/call_center/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy catalog_page from 's3://redshift-downloads/TPC-DS/2.13/100TB/catalog_page/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy catalog_returns from 's3://redshift-downloads/TPC-DS/2.13/100TB/catalog_returns/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy catalog_sales from 's3://redshift-downloads/TPC-DS/2.13/100TB/catalog_sales/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy customer_address from 's3://redshift-downloads/TPC-DS/2.13/100TB/customer_address/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy customer_demographics from 's3://redshift-downloads/TPC-DS/2.13/100TB/customer_demographics/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy customer from 's3://redshift-downloads/TPC-DS/2.13/100TB/customer/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy date_dim from 's3://redshift-downloads/TPC-DS/2.13/100TB/date_dim/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy household_demographics from 's3://redshift-downloads/TPC-DS/2.13/100TB/household_demographics/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy income_band from 's3://redshift-downloads/TPC-DS/2.13/100TB/income_band/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy inventory from 's3://redshift-downloads/TPC-DS/2.13/100TB/inventory/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy item from 's3://redshift-downloads/TPC-DS/2.13/100TB/item/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy promotion from 's3://redshift-downloads/TPC-DS/2.13/100TB/promotion/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy reason from 's3://redshift-downloads/TPC-DS/2.13/100TB/reason/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy ship_mode from 's3://redshift-downloads/TPC-DS/2.13/100TB/ship_mode/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy store from 's3://redshift-downloads/TPC-DS/2.13/100TB/store/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy store_returns from 's3://redshift-downloads/TPC-DS/2.13/100TB/store_returns/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy store_sales from 's3://redshift-downloads/TPC-DS/2.13/100TB/store_sales/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy time_dim from 's3://redshift-downloads/TPC-DS/2.13/100TB/time_dim/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy warehouse from 's3://redshift-downloads/TPC-DS/2.13/100TB/warehouse/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy web_page from 's3://redshift-downloads/TPC-DS/2.13/100TB/web_page/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy web_returns from 's3://redshift-downloads/TPC-DS/2.13/100TB/web_returns/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy web_sales from 's3://redshift-downloads/TPC-DS/2.13/100TB/web_sales/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy web_site from 's3://redshift-downloads/TPC-DS/2.13/100TB/web_site/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy call_center from 's3://redshift-downloads/TPC-DS/2.13/100TB/call_center/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy catalog_page from 's3://redshift-downloads/TPC-DS/2.13/100TB/catalog_page/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy catalog_returns from 's3://redshift-downloads/TPC-DS/2.13/100TB/catalog_returns/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy catalog_sales from 's3://redshift-downloads/TPC-DS/2.13/100TB/catalog_sales/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy customer_address from 's3://redshift-downloads/TPC-DS/2.13/100TB/customer_address/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy customer_demographics from 's3://redshift-downloads/TPC-DS/2.13/100TB/customer_demographics/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy customer from 's3://redshift-downloads/TPC-DS/2.13/100TB/customer/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy date_dim from 's3://redshift-downloads/TPC-DS/2.13/100TB/date_dim/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy household_demographics from 's3://redshift-downloads/TPC-DS/2.13/100TB/household_demographics/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy income_band from 's3://redshift-downloads/TPC-DS/2.13/100TB/income_band/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy inventory from 's3://redshift-downloads/TPC-DS/2.13/100TB/inventory/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy item from 's3://redshift-downloads/TPC-DS/2.13/100TB/item/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy promotion from 's3://redshift-downloads/TPC-DS/2.13/100TB/promotion/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy reason from 's3://redshift-downloads/TPC-DS/2.13/100TB/reason/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy ship_mode from 's3://redshift-downloads/TPC-DS/2.13/100TB/ship_mode/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy store from 's3://redshift-downloads/TPC-DS/2.13/100TB/store/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy store_returns from 's3://redshift-downloads/TPC-DS/2.13/100TB/store_returns/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy store_sales from 's3://redshift-downloads/TPC-DS/2.13/100TB/store_sales/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy time_dim from 's3://redshift-downloads/TPC-DS/2.13/100TB/time_dim/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy warehouse from 's3://redshift-downloads/TPC-DS/2.13/100TB/warehouse/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy web_page from 's3://redshift-downloads/TPC-DS/2.13/100TB/web_page/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy web_returns from 's3://redshift-downloads/TPC-DS/2.13/100TB/web_returns/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy web_sales from 's3://redshift-downloads/TPC-DS/2.13/100TB/web_sales/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy web_site from 's3://redshift-downloads/TPC-DS/2.13/100TB/web_site/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
 
 select count(*) from call_center; -- 60
 select count(*) from catalog_page; -- 50000

--- a/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCDS/10TB/ddl.sql
+++ b/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCDS/10TB/ddl.sql
@@ -552,42 +552,51 @@ ss_sold_date_sk int4 ,
 ) distkey(ss_item_sk) sortkey(ss_sold_date_sk);
 
 /*
-	To load the sample data, you must provide authentication for your cluster to access Amazon S3 on your behalf.
-	You can provide either role-based authentication or key-based authentication.
+
 
 	Text files needed to load test data under s3://redshift-downloads/TPC-DS/2.13/10TB are publicly available.
-	Any valid credentials should have read access.
+	
+  To load the sample data, you must provide authentication for your cluster to access Amazon S3 on your behalf.
 
-	The COPY commands include a placeholder for the aws_access_key_id and aws_secret_access_key.
-	User must update the credentials clause below with valid credentials or the command will fail.
+  You can provide authentication by referencing an IAM role that you have created. You can set an IAM_Role as the default for your cluster or you can directly provide the ARN of an IAM_Role.  
+  For more information https://docs.aws.amazon.com/redshift/latest/mgmt/authorizing-redshift-service.html
 
-	For more information check samples in https://docs.aws.amazon.com/redshift/latest/gsg/rs-gsg-create-sample-db.html
+  The COPY commands include a placeholder for IAM_Role, in this code IAM_Role clause is set to use the default IAM_Role. If your cluster does not have a IAM_Role set as default then please follow the instructions provided here:
+
+  https://docs.aws.amazon.com/redshift/latest/mgmt/default-iam-role.html
+
+  For more information check samples in https://docs.aws.amazon.com/redshift/latest/gsg/rs-gsg-create-sample-db.html
+
+  **Note** another option to provide IAM_Role is to provide IAM_Role ARN in IAM_Role clause. For example
+  copy call_center from 's3://redshift-downloads/TPC-DS/2.13/10TB/call_center/' IAM_Role 'Replace text inside the quotes with Redshift cluster IAM_Role ARN' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+	
 */
 
-copy call_center from 's3://redshift-downloads/TPC-DS/2.13/10TB/call_center/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
-copy catalog_page from 's3://redshift-downloads/TPC-DS/2.13/10TB/catalog_page/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
-copy catalog_returns from 's3://redshift-downloads/TPC-DS/2.13/10TB/catalog_returns/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
-copy catalog_sales from 's3://redshift-downloads/TPC-DS/2.13/10TB/catalog_sales/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
-copy customer_address from 's3://redshift-downloads/TPC-DS/2.13/10TB/customer_address/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
-copy customer_demographics from 's3://redshift-downloads/TPC-DS/2.13/10TB/customer_demographics/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
-copy customer from 's3://redshift-downloads/TPC-DS/2.13/10TB/customer/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
-copy date_dim from 's3://redshift-downloads/TPC-DS/2.13/10TB/date_dim/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
-copy household_demographics from 's3://redshift-downloads/TPC-DS/2.13/10TB/household_demographics/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
-copy income_band from 's3://redshift-downloads/TPC-DS/2.13/10TB/income_band/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
-copy inventory from 's3://redshift-downloads/TPC-DS/2.13/10TB/inventory/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
-copy item from 's3://redshift-downloads/TPC-DS/2.13/10TB/item/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
-copy promotion from 's3://redshift-downloads/TPC-DS/2.13/10TB/promotion/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
-copy reason from 's3://redshift-downloads/TPC-DS/2.13/10TB/reason/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
-copy ship_mode from 's3://redshift-downloads/TPC-DS/2.13/10TB/ship_mode/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
-copy store from 's3://redshift-downloads/TPC-DS/2.13/10TB/store/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
-copy store_returns from 's3://redshift-downloads/TPC-DS/2.13/10TB/store_returns/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
-copy store_sales from 's3://redshift-downloads/TPC-DS/2.13/10TB/store_sales/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|'  EMPTYASNULL region 'us-east-1';
-copy time_dim from 's3://redshift-downloads/TPC-DS/2.13/10TB/time_dim/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
-copy warehouse from 's3://redshift-downloads/TPC-DS/2.13/10TB/warehouse/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
-copy web_page from 's3://redshift-downloads/TPC-DS/2.13/10TB/web_page/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
-copy web_returns from 's3://redshift-downloads/TPC-DS/2.13/10TB/web_returns/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
-copy web_sales from 's3://redshift-downloads/TPC-DS/2.13/10TB/web_sales/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
-copy web_site from 's3://redshift-downloads/TPC-DS/2.13/10TB/web_site/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy call_center from 's3://redshift-downloads/TPC-DS/2.13/10TB/call_center/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy catalog_page from 's3://redshift-downloads/TPC-DS/2.13/10TB/catalog_page/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy catalog_returns from 's3://redshift-downloads/TPC-DS/2.13/10TB/catalog_returns/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy catalog_sales from 's3://redshift-downloads/TPC-DS/2.13/10TB/catalog_sales/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy customer_address from 's3://redshift-downloads/TPC-DS/2.13/10TB/customer_address/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy customer_demographics from 's3://redshift-downloads/TPC-DS/2.13/10TB/customer_demographics/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy customer from 's3://redshift-downloads/TPC-DS/2.13/10TB/customer/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy date_dim from 's3://redshift-downloads/TPC-DS/2.13/10TB/date_dim/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy household_demographics from 's3://redshift-downloads/TPC-DS/2.13/10TB/household_demographics/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy income_band from 's3://redshift-downloads/TPC-DS/2.13/10TB/income_band/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy inventory from 's3://redshift-downloads/TPC-DS/2.13/10TB/inventory/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy item from 's3://redshift-downloads/TPC-DS/2.13/10TB/item/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy promotion from 's3://redshift-downloads/TPC-DS/2.13/10TB/promotion/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy reason from 's3://redshift-downloads/TPC-DS/2.13/10TB/reason/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy ship_mode from 's3://redshift-downloads/TPC-DS/2.13/10TB/ship_mode/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy store from 's3://redshift-downloads/TPC-DS/2.13/10TB/store/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy store_returns from 's3://redshift-downloads/TPC-DS/2.13/10TB/store_returns/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy store_sales from 's3://redshift-downloads/TPC-DS/2.13/10TB/store_sales/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy time_dim from 's3://redshift-downloads/TPC-DS/2.13/10TB/time_dim/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy warehouse from 's3://redshift-downloads/TPC-DS/2.13/10TB/warehouse/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy web_page from 's3://redshift-downloads/TPC-DS/2.13/10TB/web_page/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy web_returns from 's3://redshift-downloads/TPC-DS/2.13/10TB/web_returns/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy web_sales from 's3://redshift-downloads/TPC-DS/2.13/10TB/web_sales/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+copy web_site from 's3://redshift-downloads/TPC-DS/2.13/10TB/web_site/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1' ;
+
 
 select count(*) from call_center; -- 54
 select count(*) from catalog_page; -- 40000

--- a/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCDS/30TB/ddl.sql
+++ b/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCDS/30TB/ddl.sql
@@ -552,42 +552,47 @@ ss_sold_date_sk int4 ,
 ) distkey(ss_item_sk) sortkey(ss_sold_date_sk);
 
 /*
-	To load the sample data, you must provide authentication for your cluster to access Amazon S3 on your behalf.
-	You can provide either role-based authentication or key-based authentication.
-
 	Text files needed to load test data under s3://redshift-downloads/TPC-DS/2.13/30TB are publicly available.
-	Any valid credentials should have read access.
+	
+  To load the sample data, you must provide authentication for your cluster to access Amazon S3 on your behalf.
 
-	The COPY commands include a placeholder for the aws_access_key_id and aws_secret_access_key.
-	User must update the credentials clause below with valid credentials or the command will fail.
+  You can provide authentication by referencing an IAM role that you have created. You can set an IAM_Role as the default for your cluster or you can directly provide the ARN of an IAM_Role.  
+  For more information https://docs.aws.amazon.com/redshift/latest/mgmt/authorizing-redshift-service.html
 
-	For more information check samples in https://docs.aws.amazon.com/redshift/latest/gsg/rs-gsg-create-sample-db.html
+  The COPY commands include a placeholder for IAM_Role, in this code IAM_Role clause is set to use the default IAM_Role. If your cluster does not have a IAM_Role set as default then please follow the instructions provided here:
+
+  https://docs.aws.amazon.com/redshift/latest/mgmt/default-iam-role.html
+
+  For more information check samples in https://docs.aws.amazon.com/redshift/latest/gsg/rs-gsg-create-sample-db.html
+
+  **Note** another option to provide IAM_Role is to provide IAM_Role ARN in IAM_Role clause. For example
+  copy call_center from 's3://redshift-downloads/TPC-DS/2.13/30TB/call_center/' IAM_Role 'Replace text inside the quotes with Redshift cluster IAM_Role ARN' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
 */
 
-copy call_center from 's3://redshift-downloads/TPC-DS/2.13/30TB/call_center/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|'  EMPTYASNULL region 'us-east-1';
-copy catalog_page from 's3://redshift-downloads/TPC-DS/2.13/30TB/catalog_page/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|'  EMPTYASNULL region 'us-east-1';
-copy catalog_returns from 's3://redshift-downloads/TPC-DS/2.13/30TB/catalog_returns/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|'  EMPTYASNULL region 'us-east-1';
-copy catalog_sales from 's3://redshift-downloads/TPC-DS/2.13/30TB/catalog_sales/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|'  EMPTYASNULL region 'us-east-1';
-copy customer_address from 's3://redshift-downloads/TPC-DS/2.13/30TB/customer_address/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|'  EMPTYASNULL region 'us-east-1';
-copy customer_demographics from 's3://redshift-downloads/TPC-DS/2.13/30TB/customer_demographics/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|'  EMPTYASNULL region 'us-east-1';
-copy customer from 's3://redshift-downloads/TPC-DS/2.13/30TB/customer/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|'  EMPTYASNULL region 'us-east-1';
-copy date_dim from 's3://redshift-downloads/TPC-DS/2.13/30TB/date_dim/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|'  EMPTYASNULL region 'us-east-1';
-copy household_demographics from 's3://redshift-downloads/TPC-DS/2.13/30TB/household_demographics/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|'  EMPTYASNULL region 'us-east-1';
-copy income_band from 's3://redshift-downloads/TPC-DS/2.13/30TB/income_band/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|'  EMPTYASNULL region 'us-east-1';
-copy inventory from 's3://redshift-downloads/TPC-DS/2.13/30TB/inventory/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|'  EMPTYASNULL region 'us-east-1';
-copy item from 's3://redshift-downloads/TPC-DS/2.13/30TB/item/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|'  EMPTYASNULL region 'us-east-1';
-copy promotion from 's3://redshift-downloads/TPC-DS/2.13/30TB/promotion/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|'  EMPTYASNULL region 'us-east-1';
-copy reason from 's3://redshift-downloads/TPC-DS/2.13/30TB/reason/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|'  EMPTYASNULL region 'us-east-1';
-copy ship_mode from 's3://redshift-downloads/TPC-DS/2.13/30TB/ship_mode/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL  region 'us-east-1';
-copy store from 's3://redshift-downloads/TPC-DS/2.13/30TB/store/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy store_returns from 's3://redshift-downloads/TPC-DS/2.13/30TB/store_returns/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|'  EMPTYASNULL region 'us-east-1';
-copy store_sales from 's3://redshift-downloads/TPC-DS/2.13/30TB/store_sales/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|'  EMPTYASNULL region 'us-east-1';
-copy time_dim from 's3://redshift-downloads/TPC-DS/2.13/30TB/time_dim/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy warehouse from 's3://redshift-downloads/TPC-DS/2.13/30TB/warehouse/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy web_page from 's3://redshift-downloads/TPC-DS/2.13/30TB/web_page/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy web_returns from 's3://redshift-downloads/TPC-DS/2.13/30TB/web_returns/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|'  EMPTYASNULL region 'us-east-1';
-copy web_sales from 's3://redshift-downloads/TPC-DS/2.13/30TB/web_sales/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|'  EMPTYASNULL region 'us-east-1';
-copy web_site from 's3://redshift-downloads/TPC-DS/2.13/30TB/web_site/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy call_center from 's3://redshift-downloads/TPC-DS/2.13/30TB/call_center/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy catalog_page from 's3://redshift-downloads/TPC-DS/2.13/30TB/catalog_page/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy catalog_returns from 's3://redshift-downloads/TPC-DS/2.13/30TB/catalog_returns/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy catalog_sales from 's3://redshift-downloads/TPC-DS/2.13/30TB/catalog_sales/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy customer_address from 's3://redshift-downloads/TPC-DS/2.13/30TB/customer_address/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy customer_demographics from 's3://redshift-downloads/TPC-DS/2.13/30TB/customer_demographics/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy customer from 's3://redshift-downloads/TPC-DS/2.13/30TB/customer/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy date_dim from 's3://redshift-downloads/TPC-DS/2.13/30TB/date_dim/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy household_demographics from 's3://redshift-downloads/TPC-DS/2.13/30TB/household_demographics/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy income_band from 's3://redshift-downloads/TPC-DS/2.13/30TB/income_band/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy inventory from 's3://redshift-downloads/TPC-DS/2.13/30TB/inventory/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy item from 's3://redshift-downloads/TPC-DS/2.13/30TB/item/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy promotion from 's3://redshift-downloads/TPC-DS/2.13/30TB/promotion/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy reason from 's3://redshift-downloads/TPC-DS/2.13/30TB/reason/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy ship_mode from 's3://redshift-downloads/TPC-DS/2.13/30TB/ship_mode/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy store from 's3://redshift-downloads/TPC-DS/2.13/30TB/store/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy store_returns from 's3://redshift-downloads/TPC-DS/2.13/30TB/store_returns/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy store_sales from 's3://redshift-downloads/TPC-DS/2.13/30TB/store_sales/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy time_dim from 's3://redshift-downloads/TPC-DS/2.13/30TB/time_dim/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy warehouse from 's3://redshift-downloads/TPC-DS/2.13/30TB/warehouse/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy web_page from 's3://redshift-downloads/TPC-DS/2.13/30TB/web_page/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy web_returns from 's3://redshift-downloads/TPC-DS/2.13/30TB/web_returns/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy web_sales from 's3://redshift-downloads/TPC-DS/2.13/30TB/web_sales/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy web_site from 's3://redshift-downloads/TPC-DS/2.13/30TB/web_site/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
 
 select count(*) from call_center; -- 60
 select count(*) from catalog_page; -- 46000

--- a/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCDS/3TB/ddl.sql
+++ b/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCDS/3TB/ddl.sql
@@ -552,42 +552,49 @@ ss_sold_date_sk int4 ,
 ) distkey(ss_item_sk) sortkey(ss_sold_date_sk);
 
 /*
-	To load the sample data, you must provide authentication for your cluster to access Amazon S3 on your behalf.
-	You can provide either role-based authentication or key-based authentication.
-
 	Text files needed to load test data under s3://redshift-downloads/TPC-DS/2.13/3TB are publicly available.
-	Any valid credentials should have read access.
+	
+  To load the sample data, you must provide authentication for your cluster to access Amazon S3 on your behalf.
 
-	The COPY commands include a placeholder for the aws_access_key_id and aws_secret_access_key.
-	User must update the credentials clause below with valid credentials or the command will fail.
+  You can provide authentication by referencing an IAM role that you have created. You can set an IAM_Role as the default for your cluster or you can directly provide the ARN of an IAM_Role.  
+  For more information https://docs.aws.amazon.com/redshift/latest/mgmt/authorizing-redshift-service.html
 
-	For more information check samples in https://docs.aws.amazon.com/redshift/latest/gsg/rs-gsg-create-sample-db.html
+  The COPY commands include a placeholder for IAM_Role, in this code IAM_Role clause is set to use the default IAM_Role. If your cluster does not have a IAM_Role set as default then please follow the instructions provided here:
+
+  https://docs.aws.amazon.com/redshift/latest/mgmt/default-iam-role.html
+
+  For more information check samples in https://docs.aws.amazon.com/redshift/latest/gsg/rs-gsg-create-sample-db.html
+
+  **Note** another option to provide IAM_Role is to provide IAM_Role ARN in IAM_Role clause. For example
+  copy call_center from 's3://redshift-downloads/TPC-DS/2.13/3TB/call_center/' IAM_Role 'Replace text inside the quotes with Redshift cluster IAM_Role ARN' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
 */
 
-copy call_center from 's3://redshift-downloads/TPC-DS/2.13/3TB/call_center/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy catalog_page from 's3://redshift-downloads/TPC-DS/2.13/3TB/catalog_page/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy catalog_returns from 's3://redshift-downloads/TPC-DS/2.13/3TB/catalog_returns/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy catalog_sales from 's3://redshift-downloads/TPC-DS/2.13/3TB/catalog_sales/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy customer_address from 's3://redshift-downloads/TPC-DS/2.13/3TB/customer_address/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy customer_demographics from 's3://redshift-downloads/TPC-DS/2.13/3TB/customer_demographics/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy customer from 's3://redshift-downloads/TPC-DS/2.13/3TB/customer/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy date_dim from 's3://redshift-downloads/TPC-DS/2.13/3TB/date_dim/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy household_demographics from 's3://redshift-downloads/TPC-DS/2.13/3TB/household_demographics/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy income_band from 's3://redshift-downloads/TPC-DS/2.13/3TB/income_band/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy inventory from 's3://redshift-downloads/TPC-DS/2.13/3TB/inventory/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy item from 's3://redshift-downloads/TPC-DS/2.13/3TB/item/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy promotion from 's3://redshift-downloads/TPC-DS/2.13/3TB/promotion/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy reason from 's3://redshift-downloads/TPC-DS/2.13/3TB/reason/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy ship_mode from 's3://redshift-downloads/TPC-DS/2.13/3TB/ship_mode/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy store from 's3://redshift-downloads/TPC-DS/2.13/3TB/store/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy store_returns from 's3://redshift-downloads/TPC-DS/2.13/3TB/store_returns/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy store_sales from 's3://redshift-downloads/TPC-DS/2.13/3TB/store_sales/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy time_dim from 's3://redshift-downloads/TPC-DS/2.13/3TB/time_dim/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy warehouse from 's3://redshift-downloads/TPC-DS/2.13/3TB/warehouse/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy web_page from 's3://redshift-downloads/TPC-DS/2.13/3TB/web_page/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy web_returns from 's3://redshift-downloads/TPC-DS/2.13/3TB/web_returns/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy web_sales from 's3://redshift-downloads/TPC-DS/2.13/3TB/web_sales/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
-copy web_site from 's3://redshift-downloads/TPC-DS/2.13/3TB/web_site/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID>;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+
+
+copy call_center from 's3://redshift-downloads/TPC-DS/2.13/3TB/call_center/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy catalog_page from 's3://redshift-downloads/TPC-DS/2.13/3TB/catalog_page/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy catalog_returns from 's3://redshift-downloads/TPC-DS/2.13/3TB/catalog_returns/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy catalog_sales from 's3://redshift-downloads/TPC-DS/2.13/3TB/catalog_sales/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy customer_address from 's3://redshift-downloads/TPC-DS/2.13/3TB/customer_address/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy customer_demographics from 's3://redshift-downloads/TPC-DS/2.13/3TB/customer_demographics/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy customer from 's3://redshift-downloads/TPC-DS/2.13/3TB/customer/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy date_dim from 's3://redshift-downloads/TPC-DS/2.13/3TB/date_dim/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy household_demographics from 's3://redshift-downloads/TPC-DS/2.13/3TB/household_demographics/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy income_band from 's3://redshift-downloads/TPC-DS/2.13/3TB/income_band/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy inventory from 's3://redshift-downloads/TPC-DS/2.13/3TB/inventory/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy item from 's3://redshift-downloads/TPC-DS/2.13/3TB/item/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy promotion from 's3://redshift-downloads/TPC-DS/2.13/3TB/promotion/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy reason from 's3://redshift-downloads/TPC-DS/2.13/3TB/reason/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy ship_mode from 's3://redshift-downloads/TPC-DS/2.13/3TB/ship_mode/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy store from 's3://redshift-downloads/TPC-DS/2.13/3TB/store/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy store_returns from 's3://redshift-downloads/TPC-DS/2.13/3TB/store_returns/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy store_sales from 's3://redshift-downloads/TPC-DS/2.13/3TB/store_sales/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy time_dim from 's3://redshift-downloads/TPC-DS/2.13/3TB/time_dim/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy warehouse from 's3://redshift-downloads/TPC-DS/2.13/3TB/warehouse/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy web_page from 's3://redshift-downloads/TPC-DS/2.13/3TB/web_page/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy web_returns from 's3://redshift-downloads/TPC-DS/2.13/3TB/web_returns/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy web_sales from 's3://redshift-downloads/TPC-DS/2.13/3TB/web_sales/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
+copy web_site from 's3://redshift-downloads/TPC-DS/2.13/3TB/web_site/' iam_role default gzip delimiter '|' EMPTYASNULL region 'us-east-1';
  
 select count(*) from call_center;  -- 48
 select count(*) from catalog_page;  -- 36000

--- a/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCH/3TB/ddl.sql
+++ b/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCH/3TB/ddl.sql
@@ -93,23 +93,28 @@ create table supplier (
 ;
 
 /*
-	To load the sample data, you must provide authentication for your cluster to access Amazon S3 on your behalf.
-	You can provide either role-based authentication or key-based authentication.
+Text files needed to load test data under s3://redshift-downloads/TPC-H/3TB are publicly available. Any valid credentials can be used to access the files.
 
-	Text files needed to load test data under s3://redshift-downloads/TPC-H/3TB are publicly available.
-	Any valid credentials should have read access.
+To load the sample data, you must provide authentication for your cluster to access Amazon S3 on your behalf.
 
-	The COPY commands include a placeholder for the aws_access_key_id and aws_secret_access_key.
-	User must update the credentials clause below with valid credentials or the command will fail.
+You can provide authentication by referencing an IAM role that you have created. You can set an IAM_Role as the default for your cluster or you can directly provide the ARN of an IAM_Role.  
+For more information https://docs.aws.amazon.com/redshift/latest/mgmt/authorizing-redshift-service.html
 
-	For more information check samples in https://docs.aws.amazon.com/redshift/latest/gsg/rs-gsg-create-sample-db.html
+The COPY commands include a placeholder for IAM_Role, in this code IAM_Role clause is set to use the default IAM_Role. If your cluster does not have a IAM_Role set as default then please follow the instructions provided here:
+
+https://docs.aws.amazon.com/redshift/latest/mgmt/default-iam-role.html
+
+For more information check samples in https://docs.aws.amazon.com/redshift/latest/gsg/rs-gsg-create-sample-db.html
+
+**Note** another option to provide IAM_Role is to provide IAM_Role ARN in IAM_Role clause. For example
+copy region from's3://redshift-downloads/TPC-H/3TB/region/' IAM_Role 'Replace text inside the quotes with Redshift cluster IAM_Role ARN' gzip delimiter '|';
 */
 
-copy region from 's3://redshift-downloads/TPC-H/3TB/region/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID> ;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|';
-copy nation from 's3://redshift-downloads/TPC-H/3TB/nation/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID> ;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|';
-copy lineitem from 's3://redshift-downloads/TPC-H/3TB/lineitem/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID> ;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|';
-copy orders from 's3://redshift-downloads/TPC-H/3TB/orders/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID> ;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|';
-copy part from 's3://redshift-downloads/TPC-H/3TB/part/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID> ;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|';
-copy supplier from 's3://redshift-downloads/TPC-H/3TB/supplier/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID> ;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|';
-copy partsupp from 's3://redshift-downloads/TPC-H/3TB/partsupp/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID> ;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|';
-copy customer from 's3://redshift-downloads/TPC-H/3TB/customer/' credentials 'aws_access_key_id=<USER_ACCESS_KEY_ID> ;aws_secret_access_key=<USER_SECRET_ACCESS_KEY>' gzip delimiter '|';
+copy region from 's3://redshift-downloads/TPC-H/3TB/region/' iam_role default gzip delimiter '|';
+copy nation from 's3://redshift-downloads/TPC-H/3TB/nation/' iam_role default gzip delimiter '|';
+copy lineitem from 's3://redshift-downloads/TPC-H/3TB/lineitem/' iam_role default gzip delimiter '|';
+copy orders from 's3://redshift-downloads/TPC-H/3TB/orders/' iam_role default gzip delimiter '|';
+copy part from 's3://redshift-downloads/TPC-H/3TB/part/' iam_role default gzip delimiter '|';
+copy supplier from 's3://redshift-downloads/TPC-H/3TB/supplier/' iam_role default gzip delimiter '|';
+copy partsupp from 's3://redshift-downloads/TPC-H/3TB/partsupp/' iam_role default gzip delimiter '|';
+copy customer from 's3://redshift-downloads/TPC-H/3TB/customer/' iam_role default gzip delimiter '|';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
@sgromoll as discussed updated the copy commands to include iam_role default clause.  Removed access and secret key clause from copy commands

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
