### PR TITLE
update MetadataTransfer readme

### DIFF
--- a/src/MetadataTransfer/readme.md
+++ b/src/MetadataTransfer/readme.md
@@ -17,4 +17,7 @@ python metadatacopy.py \
 ```
 
 ## Limitations
-While copying object privileges, all or none of the privileges will be transferred to the target. If any privilege fail to apply at target, all privileges will be rolled back for that transaction.
+
+* While copying object privileges, all or none of the privileges will be transferred to the target. If any privilege fail to apply at target, all privileges will be rolled back for that transaction.
+
+* When copying users, the utility uses a command similar to `create user <username> password disable;`. The password field is set to `disable` because it is not possible (due to security concerns) to extract plain text passwords for users in a cluster.

--- a/src/MetadataTransfer/readme.md
+++ b/src/MetadataTransfer/readme.md
@@ -4,7 +4,17 @@ This utility enables the end user to automate the transfer of metadata from one 
 The utility requries [`psycopg2`](https://pypi.org/project/psycopg2/) and the `boto3` SDK. Additionally, the utility requires that you configure the [default region](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-region) for `boto3` to successfully send requests.
 
 ## Usage
-```python metadatatransfer.py --tgtcluster <target cluster endpoint> --srccluster <source cluster endpoint> --tgtuser <target superuser> --srcuser <source superuser> --tgtdbname <target cluster dbname> --srcdbname <source cluster dbname>``` 
+
+```sh
+python metadatacopy.py \
+--tgtcluster <target cluster endpoint> \
+--srccluster <source cluster endpoint> \
+--tgtuser <target superuser> \
+--srcuser <source superuser> \
+--tgtdbname <target cluster dbname> \
+--srcdbname <source cluster dbname> \
+[--dbport <database port>]
+```
 
 ## Limitations
 While copying object privileges, all or none of the privileges will be transferred to the target. If any privilege fail to apply at target, all privileges will be rolled back for that transaction.

--- a/src/MetadataTransfer/readme.md
+++ b/src/MetadataTransfer/readme.md
@@ -1,5 +1,7 @@
 # Metadata transfer utility
-This utility enables the end user to automate the transfer of metadata from one cluster to another. Metadata includes users, user profiles, groups, databases, schemas and related privileges. The utility is compatible with python 2.7. 
+This utility enables the end user to automate the transfer of metadata from one cluster to another. Metadata includes users, user profiles, groups, databases, schemas and related privileges. The utility is compatible with python 2.7.
+
+The utility requries [`psycopg2`](https://pypi.org/project/psycopg2/) and the `boto3` SDK. Additionally, the utility requires that you configure the [default region](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-region) for `boto3` to successfully send requests.
 
 ## Usage
 ```python metadatatransfer.py --tgtcluster <target cluster endpoint> --srccluster <source cluster endpoint> --tgtuser <target superuser> --srcuser <source superuser> --tgtdbname <target cluster dbname> --srcdbname <source cluster dbname>``` 


### PR DESCRIPTION
*Issue #, if available:* #598

*Description of changes:*

Additions:

* Added information about the required packages for successfully running the script. Currently, the script requires `psycopg2` and `boto3`.
* Added info that the utility requires [default region](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-region) to be configured.
* Added additional limitation that when transferring users, the password is set to `disable`

Modifications:

Updated the usage information as below

Changed filename from `metadatatransfer.py` to `metadatacopy.py` and added the `--dbport` [option](https://github.com/awslabs/amazon-redshift-utils/blob/60296701e9605148c48defe48b38366107cbccd1/src/MetadataTransfer/metadatacopy.py#L139) argument.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
