### PR TITLE
Update v_find_dropuser_objs.sql

### DIFF
--- a/src/AdminViews/v_find_dropuser_objs.sql
+++ b/src/AdminViews/v_find_dropuser_objs.sql
@@ -31,7 +31,7 @@ SELECT owner.objtype,
 FROM (
 -- Functions owned by the user
      SELECT 'Function',pgu.usename,pgu.usesysid,nc.nspname,textin (regprocedureout (pproc.oid::regprocedure)),
-     'alter function ' || QUOTE_IDENT(nc.nspname) || '.' ||textin (regprocedureout (pproc.oid::regprocedure)) || ' owner to ' 
+     'alter '|| case when prorettype = 0::oid then 'procedure' else 'function' end || ' ' ||  textin (regprocedureout (pproc.oid::regprocedure)) || ' owner to ' 
      FROM pg_proc pproc,pg_user pgu,pg_namespace nc
 WHERE pproc.pronamespace = nc.oid
 AND   pproc.proowner = pgu.usesysid


### PR DESCRIPTION
*Description of changes:*
The generated alter statement for Functions does not handle the difference between functions and procedures today. 

Reviewing the pg_catalog.pg_proc_info view, which does distinguish between a function and procedure, this is done with the prorettype field, indicating the type of return by the function. Stored procedures do not support returns unlike functions, and the return type for a procedure is listed as 0. 

I've added a case statement to differentiate between them in the statement generated, and in my tests of creating functions, procedures, and modifying ownership of them, this was able to generate the correct statements per type. 

I've also removed the duplicated schema name based on testing by making a change from my default session being in a different schema from public. In my testing, all other functions were created in a dedicated schema, and the process to generate the function/procedure name to be altered already contains the schema name, thus generating duplicates. When it comes to altering public schema created functions, qualifying the schema did not seem to impact my ability to run the alter statement successfully.

SQL used in testing:
```sql
create function gtm_de.function_test_greater (float, float)
  returns float
stable
as $$
  select case when $1 > $2 then $1
    else $2
  end
$$ language sql;

select gtm_de.function_test_greater(5,(2+2));

select * from pg_catalog.pg_proc p where p.proname like 'function%';
select * from pg_catalog.pg_proc_info p where p.proname like 'funct%'
--prorettype = 0::oid

--alter function gtm_de.gtm_de.function_test_greater(double precision,double precision) owner to user1;
alter function gtm_de.function_test_greater(double precision,double precision) owner to user2;
--alter procedure gtm_de.function_test_greater(double precision,double precision) owner to user1;


--prorettype = 0::oid


CREATE OR REPLACE PROCEDURE gtm_de.procedure_test(greet_user varchar(20))
AS $$
DECLARE
  min_val int;
BEGIN
  select 'hello ' || greet_user;
END;
$$ LANGUAGE plpgsql;


alter procedure gtm_de.procedure_test(character varying) owner to user2;

--in the public schema
alter procedure terminate_and_log_inactive_sessions(integer) owner to user3
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
