### PR TITLE
Fix default debug to not print out password

### DIFF
--- a/src/AnalyzeVacuumUtility/lib/analyze_vacuum.py
+++ b/src/AnalyzeVacuumUtility/lib/analyze_vacuum.py
@@ -628,7 +628,7 @@ def run_analyze_vacuum(**kwargs):
     global debug
     if config_constants.DEBUG in os.environ:
         debug = os.environ[config_constants.DEBUG]
-    if config_constants.DEBUG in kwargs and kwargs[config_constants.DEBUG]:
+    if config_constants.DEBUG in kwargs and kwargs[config_constants.DEBUG] != 'false':
         debug = True
 
     # connect to cloudwatch


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changing the analyze vacuum script to not set debug to True if false gets passed to the script as it does now if DEBUG is not set in the entrypoint

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
