### PR TITLE
Add COUNT(*) in DDL of CloudDataWarehouseBenchmark/TPC-H

### DIFF
--- a/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCH/10GB/ddl.sql
+++ b/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCH/10GB/ddl.sql
@@ -118,3 +118,12 @@ copy part from 's3://redshift-downloads/TPC-H/2.18/10GB/part.tbl' iam_role defau
 copy supplier from 's3://redshift-downloads/TPC-H/2.18/10GB/supplier.tbl' iam_role default delimiter '|';
 copy partsupp from 's3://redshift-downloads/TPC-H/2.18/10GB/partsupp.tbl' iam_role default delimiter '|';
 copy customer from 's3://redshift-downloads/TPC-H/2.18/10GB/customer.tbl' iam_role default delimiter '|';
+
+select count(*) from customer;  -- 1500000
+select count(*) from lineitem;  -- 59986052
+select count(*) from nation;  -- 25
+select count(*) from orders;  -- 15000000
+select count(*) from part;  -- 2000000
+select count(*) from partsupp;  -- 8000000
+select count(*) from region;  -- 5
+select count(*) from supplier;  -- 100000

--- a/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCH/30TB/ddl.sql
+++ b/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCH/30TB/ddl.sql
@@ -118,3 +118,12 @@ copy part from 's3://redshift-downloads/TPC-H/2.18/30TB/part/' iam_role default 
 copy supplier from 's3://redshift-downloads/TPC-H/2.18/30TB/supplier/' iam_role default gzip delimiter '|';
 copy partsupp from 's3://redshift-downloads/TPC-H/2.18/30TB/partsupp/' iam_role default gzip delimiter '|';
 copy customer from 's3://redshift-downloads/TPC-H/2.18/30TB/customer/' iam_role default gzip delimiter '|';
+
+select count(*) from customer;  -- 4500000000
+select count(*) from lineitem;  -- 179999978268
+select count(*) from nation;  -- 25
+select count(*) from orders;  -- 45000000000
+select count(*) from part;  -- 6000000000
+select count(*) from partsupp;  -- 24000000000
+select count(*) from region;  -- 5
+select count(*) from supplier;  -- 300000000

--- a/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCH/3TB/ddl.sql
+++ b/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCH/3TB/ddl.sql
@@ -118,3 +118,12 @@ copy part from 's3://redshift-downloads/TPC-H/2.18/3TB/part/' iam_role default d
 copy supplier from 's3://redshift-downloads/TPC-H/2.18/3TB/supplier/' iam_role default delimiter '|';
 copy partsupp from 's3://redshift-downloads/TPC-H/2.18/3TB/partsupp/' iam_role default delimiter '|';
 copy customer from 's3://redshift-downloads/TPC-H/2.18/3TB/customer/' iam_role default delimiter '|';
+
+select count(*) from customer;  -- 450000000
+select count(*) from lineitem;  -- 18000048306
+select count(*) from nation;  -- 25
+select count(*) from orders;  -- 4500000000
+select count(*) from part;  -- 600000000
+select count(*) from partsupp;  -- 2400000000
+select count(*) from region;  -- 5
+select count(*) from supplier;  -- 30000000


### PR DESCRIPTION
*Issue #, if available:*

Fix #626

*Description of changes:*

Added count(*) to `ddl.sql` of TPC-H. 

Summary of row counts:

|table|10GB|3TB|30TB|
|:----|:----|:----|:----|
|customer |1500000|450000000|4500000000|
|lineitem |59986052|18000048306|179999978268|
|nation |25|25|25|
|orders |15000000|4500000000|45000000000|
|part |2000000|600000000|6000000000|
|partsupp |8000000|2400000000|24000000000|
|region |5|5|5|
|supplier |100000|30000000|300000000|

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
