### PR TITLE
AnalyzeVacuum Utility - fix parameter default values bug

### DIFF
--- a/src/AnalyzeVacuumUtility/README.md
+++ b/src/AnalyzeVacuumUtility/README.md
@@ -71,8 +71,8 @@ Run ANALYZE based the `stats_off` metric in `svv_table_info`. If table has a `st
 |--slot-count | No | 1 |
 |--ignore-errors | No | False |
 |--query_group | No | None |
-|--analyze-flag | No | False |
-|--vacuum-flag | No | False |
+|--analyze-flag | Yes | False |
+|--vacuum-flag | Yes | False |
 |--vacuum-parameter | No | FULL |
 |--min-unsorted-pct | No | 0.05 |
 |--max-unsorted-pct | No | 0.5 |

--- a/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
+++ b/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
@@ -55,7 +55,7 @@ NO_CONNECTION = 5
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--analyze-flag", dest="analyze_flag", required=True,
+parser.add_argument("--analyze-flag", dest="analyze_flag", required=True, default='False',
                     help="Flag to turn ON/OFF ANALYZE functionality (True or False : Default = True ")
 parser.add_argument("--max-unsorted-pct", dest="max_unsorted_pct",
                     help="Maximum unsorted percentage(% to consider a table for vacuum : Default = 50%")
@@ -69,7 +69,7 @@ parser.add_argument("--stats-off-pct ", dest="stats_off_pct",
                     help="Minimum stats off percentage(% to consider a table for analyze : Default = 10%")
 parser.add_argument("--table-name", dest="table_name",
                     help="A specific table to be Analyzed or Vacuumed if analyze-schema is not desired")
-parser.add_argument("--vacuum-flag", dest="vacuum_flag", required=True,
+parser.add_argument("--vacuum-flag", dest="vacuum_flag", required=True, default='False',
                     help="Flag to turn ON/OFF VACUUM functionality (True or False :  Default = True")
 parser.add_argument("--vacuum-parameter", dest="vacuum_parameter",
                     help="Vacuum parameters [ FULL | SORT ONLY | DELETE ONLY | REINDEX ] Default = FULL")

--- a/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
+++ b/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
@@ -52,8 +52,6 @@ TERMINATED_BY_USER = 4
 NO_CONNECTION = 5
 
 # setup cli args
-
-
 parser = argparse.ArgumentParser()
 parser.add_argument("--analyze-flag", dest="analyze_flag", required=True, default='False',
                     help="Flag to turn ON/OFF ANALYZE functionality (True or False): Default = False ")
@@ -64,7 +62,7 @@ parser.add_argument("--min-interleaved-cnt", dest="min_interleaved_cnt", type=in
 parser.add_argument("--min-interleaved-skew", dest="min_interleaved_skew",
                     help="Minimum index skew to consider a table for vacuum reindex: Default = 1.4")
 parser.add_argument("--min-unsorted-pct", dest="min_unsorted_pct",
-                        help="Minimum unsorted percentage(% to consider a table for vacuum : Default = 5%")
+                    help="Minimum unsorted percentage(% to consider a table for vacuum : Default = 5%")
 parser.add_argument("--stats-off-pct ", dest="stats_off_pct",
                     help="Minimum stats off percentage(% to consider a table for analyze : Default = 10%")
 parser.add_argument("--table-name", dest="table_name",
@@ -94,7 +92,7 @@ parser.add_argument("--schema-name", dest="schema_name",
                     help="The Schema to be Analyzed or Vacuumed (REGEX: Default = public")
 parser.add_argument("--slot-count", dest="slot_count", help="Modify the wlm_query_slot_count : Default = 1")
 parser.add_argument("--suppress-cloudwatch", dest="suppress_cw",
-                help="Don't emit CloudWatch metrics for analyze or vacuum when set to True")
+                    help="Don't emit CloudWatch metrics for analyze or vacuum when set to True")
 parser.add_argument("--db", dest="db", help="The Database to Use")
 full_args = parser.parse_args()
 

--- a/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
+++ b/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
@@ -52,8 +52,10 @@ TERMINATED_BY_USER = 4
 NO_CONNECTION = 5
 
 # setup cli args
+
+
 parser = argparse.ArgumentParser()
-parser.add_argument("--analyze-flag", dest="analyze_flag", default=True, type=bool,
+parser.add_argument("--analyze-flag", dest="analyze_flag", required=True,
                     help="Flag to turn ON/OFF ANALYZE functionality (True or False : Default = True ")
 parser.add_argument("--max-unsorted-pct", dest="max_unsorted_pct",
                     help="Maximum unsorted percentage(% to consider a table for vacuum : Default = 50%")
@@ -62,12 +64,12 @@ parser.add_argument("--min-interleaved-cnt", dest="min_interleaved_cnt", type=in
 parser.add_argument("--min-interleaved-skew", dest="min_interleaved_skew",
                     help="Minimum index skew to consider a table for vacuum reindex: Default = 1.4")
 parser.add_argument("--min-unsorted-pct", dest="min_unsorted_pct",
-                    help="Minimum unsorted percentage(% to consider a table for vacuum : Default = 5%")
+                        help="Minimum unsorted percentage(% to consider a table for vacuum : Default = 5%")
 parser.add_argument("--stats-off-pct ", dest="stats_off_pct",
                     help="Minimum stats off percentage(% to consider a table for analyze : Default = 10%")
 parser.add_argument("--table-name", dest="table_name",
                     help="A specific table to be Analyzed or Vacuumed if analyze-schema is not desired")
-parser.add_argument("--vacuum-flag", dest="vacuum_flag", default=True, type=bool,
+parser.add_argument("--vacuum-flag", dest="vacuum_flag", required=True,
                     help="Flag to turn ON/OFF VACUUM functionality (True or False :  Default = True")
 parser.add_argument("--vacuum-parameter", dest="vacuum_parameter",
                     help="Vacuum parameters [ FULL | SORT ONLY | DELETE ONLY | REINDEX ] Default = FULL")
@@ -92,9 +94,10 @@ parser.add_argument("--schema-name", dest="schema_name",
                     help="The Schema to be Analyzed or Vacuumed (REGEX: Default = public")
 parser.add_argument("--slot-count", dest="slot_count", help="Modify the wlm_query_slot_count : Default = 1")
 parser.add_argument("--suppress-cloudwatch", dest="suppress_cw",
-                    help="Don't emit CloudWatch metrics for analyze or vacuum when set to True")
+                help="Don't emit CloudWatch metrics for analyze or vacuum when set to True")
 parser.add_argument("--db", dest="db", help="The Database to Use")
 full_args = parser.parse_args()
+
 parse_args = {}
 # remove args that end up as None
 for k, v in vars(full_args).items():

--- a/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
+++ b/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
@@ -56,7 +56,7 @@ NO_CONNECTION = 5
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--analyze-flag", dest="analyze_flag", required=True, default='False',
-                    help="Flag to turn ON/OFF ANALYZE functionality (True or False : Default = True ")
+                    help="Flag to turn ON/OFF ANALYZE functionality (True or False): Default = False ")
 parser.add_argument("--max-unsorted-pct", dest="max_unsorted_pct",
                     help="Maximum unsorted percentage(% to consider a table for vacuum : Default = 50%")
 parser.add_argument("--min-interleaved-cnt", dest="min_interleaved_cnt", type=int,
@@ -70,7 +70,7 @@ parser.add_argument("--stats-off-pct ", dest="stats_off_pct",
 parser.add_argument("--table-name", dest="table_name",
                     help="A specific table to be Analyzed or Vacuumed if analyze-schema is not desired")
 parser.add_argument("--vacuum-flag", dest="vacuum_flag", required=True, default='False',
-                    help="Flag to turn ON/OFF VACUUM functionality (True or False :  Default = True")
+                    help="Flag to turn ON/OFF VACUUM functionality (True or False): Default = False")
 parser.add_argument("--vacuum-parameter", dest="vacuum_parameter",
                     help="Vacuum parameters [ FULL | SORT ONLY | DELETE ONLY | REINDEX ] Default = FULL")
 parser.add_argument("--blacklisted-tables", dest="blacklisted_tables", help="The tables we do not want to Vacuum")

--- a/src/AnalyzeVacuumUtility/lib/analyze_vacuum.py
+++ b/src/AnalyzeVacuumUtility/lib/analyze_vacuum.py
@@ -667,6 +667,8 @@ def run_analyze_vacuum(**kwargs):
 
     if debug:
         comment("Using Cluster Name %s" % cluster_name)
+        comment("Supplied Args:")
+        print(kwargs)
 
     db_pwd = None
 

--- a/src/AnalyzeVacuumUtility/lib/analyze_vacuum.py
+++ b/src/AnalyzeVacuumUtility/lib/analyze_vacuum.py
@@ -668,9 +668,6 @@ def run_analyze_vacuum(**kwargs):
     if debug:
         comment("Using Cluster Name %s" % cluster_name)
 
-        comment("Supplied Args:")
-        print(kwargs)
-
     db_pwd = None
 
     if db_pwd is None:
@@ -695,22 +692,36 @@ def run_analyze_vacuum(**kwargs):
     if master_conn is None:
         raise Exception("No Connection was established")
 
-    vacuum_flag = kwargs.get(config_constants.DO_VACUUM, True)
-    if vacuum_flag is True:
+    # Retrieve the flags from the arguments:
+    vacuum_flag = kwargs.get("vacuum_flag",'False')
+    analyze_flag = kwargs.get("analyze_flag",'False')
+
+    # Convert to Boolean
+    if(vacuum_flag == 'True'):
+        vacuum_flag_b = True
+    else:
+        vacuum_flag_b = False
+
+    if( analyze_flag == 'True'):
+        analyze_flag_b = True
+    else:
+        analyze_flag_b = False
+
+    # Evaluate wether to run vacuum or analyze or both
+    if vacuum_flag_b is True:
         # Run vacuum based on the Unsorted , Stats off and Size of the table
         run_vacuum(master_conn, cluster_name, cw, **kwargs)
     else:
-        comment("Vacuum flag arg is not set. Vacuum not performed.")
+        comment("Vacuum flag arg is set as '%s'. Vacuum not performed." % vacuum_flag )
 
-    analyze_flag = kwargs.get(config_constants.DO_ANALYZE, True)
-    if analyze_flag is True:
-        if not vacuum_flag:
+    if analyze_flag_b is True:
+        if not vacuum_flag_b:
             comment("Warning - Analyze without Vacuum may result in sub-optimal performance")
 
         # Run Analyze based on the  Stats off Metrics table
         run_analyze(master_conn, cluster_name, cw, **kwargs)
     else:
-        comment("Analyze flag arg is set as %s. Analyze is not performed." % analyze_flag)
+        comment("Analyze flag arg is set as '%s'. Analyze is not performed." % analyze_flag )
 
     comment('Processing Complete')
 


### PR DESCRIPTION
*Issue #, if available:*
#578 

*Description of changes:*
Change input parameters for analyze-flag and vacuum-flag. Change from Boolean to String to avoid argparse bug which makes the parameter always the default value regardless of what is passed in.

Update the README for the two parameters which are now defaulted to False and are required parameters

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
