### PR TITLE
Argparse format errors in AnalyzeVacuumUtility

### DIFF
--- a/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
+++ b/src/AnalyzeVacuumUtility/analyze-vacuum-schema.py
@@ -35,7 +35,7 @@ import argparse
 try:
     sys.path.append(os.path.join(os.path.dirname(__file__), "lib"))
     sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
-except:
+except Exception:
     pass
 
 import getopt
@@ -56,15 +56,15 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--analyze-flag", dest="analyze_flag", required=True, default='False',
                     help="Flag to turn ON/OFF ANALYZE functionality (True or False): Default = False ")
 parser.add_argument("--max-unsorted-pct", dest="max_unsorted_pct",
-                    help="Maximum unsorted percentage(% to consider a table for vacuum : Default = 50%")
+                    help="Maximum unsorted percentage( to consider a table for vacuum : Default = 50")
 parser.add_argument("--min-interleaved-cnt", dest="min_interleaved_cnt", type=int,
                     help="Minimum stv_interleaved_counts records to consider a table for vacuum reindex: Default = 0")
 parser.add_argument("--min-interleaved-skew", dest="min_interleaved_skew",
                     help="Minimum index skew to consider a table for vacuum reindex: Default = 1.4")
 parser.add_argument("--min-unsorted-pct", dest="min_unsorted_pct",
-                    help="Minimum unsorted percentage(% to consider a table for vacuum : Default = 5%")
+                    help="Minimum unsorted percentage( to consider a table for vacuum : Default = 5")
 parser.add_argument("--stats-off-pct ", dest="stats_off_pct",
-                    help="Minimum stats off percentage(% to consider a table for analyze : Default = 10%")
+                    help="Minimum stats off percentage( to consider a table for analyze : Default = 10")
 parser.add_argument("--table-name", dest="table_name",
                     help="A specific table to be Analyzed or Vacuumed if analyze-schema is not desired")
 parser.add_argument("--vacuum-flag", dest="vacuum_flag", required=True, default='False',

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,3 +4,4 @@ shortuuid==0.4.3
 six==1.10.0
 boto3==1.5.3
 pgpasslib==1.1.0
+redshift-connector==2.0.908


### PR DESCRIPTION

`python AnalyzeVacuumUtility/analyze-vacuum-schema.py --help`

`Traceback (most recent call last):                                                                                                          File "AnalyzeVacuumUtility/analyze-vacuum-schema.py", line 97, in <module>                                                                  full_args = parser.parse_args()                                                                                                         File "/usr/lib64/python3.6/argparse.py", line 1734, in parse_args                                                                           args, argv = self.parse_known_args(args, namespace)                                                                                     File "/usr/lib64/python3.6/argparse.py", line 1766, in parse_known_args                                                                     namespace, args = self._parse_known_args(args, namespace)                                                                               File "/usr/lib64/python3.6/argparse.py", line 1972, in _parse_known_args                                                                    start_index = consume_optional(start_index)                                                                                             File "/usr/lib64/python3.6/argparse.py", line 1912, in consume_optional
    take_action(action, args, option_string)
  File "/usr/lib64/python3.6/argparse.py", line 1840, in take_action
    action(self, namespace, argument_values, option_string)
  File "/usr/lib64/python3.6/argparse.py", line 1024, in __call__
    parser.print_help()
  File "/usr/lib64/python3.6/argparse.py", line 2366, in print_help                                                                           self._print_message(self.format_help(), file)                                                                                           File "/usr/lib64/python3.6/argparse.py", line 2350, in format_help
    return formatter.format_help()
  File "/usr/lib64/python3.6/argparse.py", line 282, in format_help
    help = self._root_section.format_help()
  File "/usr/lib64/python3.6/argparse.py", line 213, in format_help                                                                           item_help = join([func(*args) for func, args in self.items])
  File "/usr/lib64/python3.6/argparse.py", line 213, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])                                                                            File "/usr/lib64/python3.6/argparse.py", line 213, in format_help
    item_help = join([func(*args) for func, args in self.items])                                                                            File "/usr/lib64/python3.6/argparse.py", line 213, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/lib64/python3.6/argparse.py", line 523, in _format_action                                                                        help_text = self._expand_help(action)                                                                                                   File "/usr/lib64/python3.6/argparse.py", line 610, in _expand_help
    return self._get_help_string(action) % params
ValueError: unsupported format character 't' (0x74) at index 30`

*Description of changes:*

Remove "%" characters from argument help strings
Include `redshift_connector` in requirements.txt

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
