### PR TITLE
Explicitly set region for TPC-H data load

### DIFF
--- a/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCH/100GB/ddl.sql
+++ b/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCH/100GB/ddl.sql
@@ -110,14 +110,14 @@ For more information check samples in https://docs.aws.amazon.com/redshift/lates
 copy region from's3://redshift-downloads/TPC-H/100GB/region/' IAM_Role 'Replace text inside the quotes with Redshift cluster IAM_Role ARN' gzip delimiter '|';
 */
 
-copy region from 's3://redshift-downloads/TPC-H/2.18/100GB/region/' iam_role default delimiter '|';
-copy nation from 's3://redshift-downloads/TPC-H/2.18/100GB/nation/' iam_role default delimiter '|';
-copy lineitem from 's3://redshift-downloads/TPC-H/2.18/100GB/lineitem/' iam_role default delimiter '|';
-copy orders from 's3://redshift-downloads/TPC-H/2.18/100GB/orders/' iam_role default delimiter '|';
-copy part from 's3://redshift-downloads/TPC-H/2.18/100GB/part/' iam_role default delimiter '|';
-copy supplier from 's3://redshift-downloads/TPC-H/2.18/100GB/supplier/' iam_role default delimiter '|';
-copy partsupp from 's3://redshift-downloads/TPC-H/2.18/100GB/partsupp/' iam_role default delimiter '|';
-copy customer from 's3://redshift-downloads/TPC-H/2.18/100GB/customer/' iam_role default delimiter '|';
+copy region from 's3://redshift-downloads/TPC-H/2.18/100GB/region/' iam_role default delimiter '|' region 'us-east-1';
+copy nation from 's3://redshift-downloads/TPC-H/2.18/100GB/nation/' iam_role default delimiter '|' region 'us-east-1';
+copy lineitem from 's3://redshift-downloads/TPC-H/2.18/100GB/lineitem/' iam_role default delimiter '|' region 'us-east-1';
+copy orders from 's3://redshift-downloads/TPC-H/2.18/100GB/orders/' iam_role default delimiter '|' region 'us-east-1';
+copy part from 's3://redshift-downloads/TPC-H/2.18/100GB/part/' iam_role default delimiter '|' region 'us-east-1';
+copy supplier from 's3://redshift-downloads/TPC-H/2.18/100GB/supplier/' iam_role default delimiter '|' region 'us-east-1';
+copy partsupp from 's3://redshift-downloads/TPC-H/2.18/100GB/partsupp/' iam_role default delimiter '|' region 'us-east-1';
+copy customer from 's3://redshift-downloads/TPC-H/2.18/100GB/customer/' iam_role default delimiter '|' region 'us-east-1';
 
 select count(*) from customer;  
 select count(*) from lineitem;  

--- a/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCH/10GB/ddl.sql
+++ b/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCH/10GB/ddl.sql
@@ -110,14 +110,14 @@ For more information check samples in https://docs.aws.amazon.com/redshift/lates
 copy region from's3://redshift-downloads/TPC-H/10GB/region/' IAM_Role 'Replace text inside the quotes with Redshift cluster IAM_Role ARN' gzip delimiter '|';
 */
 
-copy region from 's3://redshift-downloads/TPC-H/2.18/10GB/region.tbl' iam_role default delimiter '|';
-copy nation from 's3://redshift-downloads/TPC-H/2.18/10GB/nation.tbl' iam_role default delimiter '|';
-copy lineitem from 's3://redshift-downloads/TPC-H/2.18/10GB/lineitem.tbl' iam_role default delimiter '|';
-copy orders from 's3://redshift-downloads/TPC-H/2.18/10GB/orders.tbl' iam_role default delimiter '|';
-copy part from 's3://redshift-downloads/TPC-H/2.18/10GB/part.tbl' iam_role default delimiter '|';
-copy supplier from 's3://redshift-downloads/TPC-H/2.18/10GB/supplier.tbl' iam_role default delimiter '|';
-copy partsupp from 's3://redshift-downloads/TPC-H/2.18/10GB/partsupp.tbl' iam_role default delimiter '|';
-copy customer from 's3://redshift-downloads/TPC-H/2.18/10GB/customer.tbl' iam_role default delimiter '|';
+copy region from 's3://redshift-downloads/TPC-H/2.18/10GB/region.tbl' iam_role default delimiter '|' region 'us-east-1';
+copy nation from 's3://redshift-downloads/TPC-H/2.18/10GB/nation.tbl' iam_role default delimiter '|' region 'us-east-1';
+copy lineitem from 's3://redshift-downloads/TPC-H/2.18/10GB/lineitem.tbl' iam_role default delimiter '|' region 'us-east-1';
+copy orders from 's3://redshift-downloads/TPC-H/2.18/10GB/orders.tbl' iam_role default delimiter '|' region 'us-east-1';
+copy part from 's3://redshift-downloads/TPC-H/2.18/10GB/part.tbl' iam_role default delimiter '|' region 'us-east-1';
+copy supplier from 's3://redshift-downloads/TPC-H/2.18/10GB/supplier.tbl' iam_role default delimiter '|' region 'us-east-1';
+copy partsupp from 's3://redshift-downloads/TPC-H/2.18/10GB/partsupp.tbl' iam_role default delimiter '|' region 'us-east-1';
+copy customer from 's3://redshift-downloads/TPC-H/2.18/10GB/customer.tbl' iam_role default delimiter '|' region 'us-east-1';
 
 select count(*) from customer;  -- 1500000
 select count(*) from lineitem;  -- 59986052

--- a/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCH/30TB/ddl.sql
+++ b/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCH/30TB/ddl.sql
@@ -110,14 +110,14 @@ For more information check samples in https://docs.aws.amazon.com/redshift/lates
 copy region from's3://redshift-downloads/TPC-H/3TB/region/' IAM_Role 'Replace text inside the quotes with Redshift cluster IAM_Role ARN' gzip delimiter '|';
 */
 
-copy region from 's3://redshift-downloads/TPC-H/2.18/30TB/region/' iam_role default delimiter '|';
-copy nation from 's3://redshift-downloads/TPC-H/2.18/30TB/nation/' iam_role default delimiter '|';
-copy lineitem from 's3://redshift-downloads/TPC-H/2.18/30TB/lineitem/' iam_role default gzip delimiter '|';
-copy orders from 's3://redshift-downloads/TPC-H/2.18/30TB/orders/' iam_role default gzip delimiter '|';
-copy part from 's3://redshift-downloads/TPC-H/2.18/30TB/part/' iam_role default gzip delimiter '|';
-copy supplier from 's3://redshift-downloads/TPC-H/2.18/30TB/supplier/' iam_role default gzip delimiter '|';
-copy partsupp from 's3://redshift-downloads/TPC-H/2.18/30TB/partsupp/' iam_role default gzip delimiter '|';
-copy customer from 's3://redshift-downloads/TPC-H/2.18/30TB/customer/' iam_role default gzip delimiter '|';
+copy region from 's3://redshift-downloads/TPC-H/2.18/30TB/region/' iam_role default delimiter '|' region 'us-east-1';
+copy nation from 's3://redshift-downloads/TPC-H/2.18/30TB/nation/' iam_role default delimiter '|' region 'us-east-1';
+copy lineitem from 's3://redshift-downloads/TPC-H/2.18/30TB/lineitem/' iam_role default gzip delimiter '|' region 'us-east-1';
+copy orders from 's3://redshift-downloads/TPC-H/2.18/30TB/orders/' iam_role default gzip delimiter '|' region 'us-east-1';
+copy part from 's3://redshift-downloads/TPC-H/2.18/30TB/part/' iam_role default gzip delimiter '|' region 'us-east-1';
+copy supplier from 's3://redshift-downloads/TPC-H/2.18/30TB/supplier/' iam_role default gzip delimiter '|' region 'us-east-1';
+copy partsupp from 's3://redshift-downloads/TPC-H/2.18/30TB/partsupp/' iam_role default gzip delimiter '|' region 'us-east-1';
+copy customer from 's3://redshift-downloads/TPC-H/2.18/30TB/customer/' iam_role default gzip delimiter '|' region 'us-east-1';
 
 select count(*) from customer;  -- 4500000000
 select count(*) from lineitem;  -- 179999978268

--- a/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCH/3TB/ddl.sql
+++ b/src/CloudDataWarehouseBenchmark/Cloud-DWB-Derived-from-TPCH/3TB/ddl.sql
@@ -110,14 +110,14 @@ For more information check samples in https://docs.aws.amazon.com/redshift/lates
 copy region from's3://redshift-downloads/TPC-H/3TB/region/' IAM_Role 'Replace text inside the quotes with Redshift cluster IAM_Role ARN' gzip delimiter '|';
 */
 
-copy region from 's3://redshift-downloads/TPC-H/2.18/3TB/region/' iam_role default delimiter '|';
-copy nation from 's3://redshift-downloads/TPC-H/2.18/3TB/nation/' iam_role default delimiter '|';
-copy lineitem from 's3://redshift-downloads/TPC-H/2.18/3TB/lineitem/' iam_role default delimiter '|';
-copy orders from 's3://redshift-downloads/TPC-H/2.18/3TB/orders/' iam_role default delimiter '|';
-copy part from 's3://redshift-downloads/TPC-H/2.18/3TB/part/' iam_role default delimiter '|';
-copy supplier from 's3://redshift-downloads/TPC-H/2.18/3TB/supplier/' iam_role default delimiter '|';
-copy partsupp from 's3://redshift-downloads/TPC-H/2.18/3TB/partsupp/' iam_role default delimiter '|';
-copy customer from 's3://redshift-downloads/TPC-H/2.18/3TB/customer/' iam_role default delimiter '|';
+copy region from 's3://redshift-downloads/TPC-H/2.18/3TB/region/' iam_role default delimiter '|' region 'us-east-1';
+copy nation from 's3://redshift-downloads/TPC-H/2.18/3TB/nation/' iam_role default delimiter '|' region 'us-east-1';
+copy lineitem from 's3://redshift-downloads/TPC-H/2.18/3TB/lineitem/' iam_role default delimiter '|' region 'us-east-1';
+copy orders from 's3://redshift-downloads/TPC-H/2.18/3TB/orders/' iam_role default delimiter '|' region 'us-east-1';
+copy part from 's3://redshift-downloads/TPC-H/2.18/3TB/part/' iam_role default delimiter '|' region 'us-east-1';
+copy supplier from 's3://redshift-downloads/TPC-H/2.18/3TB/supplier/' iam_role default delimiter '|' region 'us-east-1';
+copy partsupp from 's3://redshift-downloads/TPC-H/2.18/3TB/partsupp/' iam_role default delimiter '|' region 'us-east-1';
+copy customer from 's3://redshift-downloads/TPC-H/2.18/3TB/customer/' iam_role default delimiter '|' region 'us-east-1';
 
 select count(*) from customer;  -- 450000000
 select count(*) from lineitem;  -- 18000048306


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*  Explicitly specify region in TPC-H for tests not run in us-east-1.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
