### PR TITLE
Update v_get_tbl_priv_by_group.sql

### DIFF
--- a/src/AdminViews/v_get_tbl_priv_by_group.sql
+++ b/src/AdminViews/v_get_tbl_priv_by_group.sql
@@ -7,12 +7,12 @@ History:
 create or replace view admin.v_get_tbl_priv_by_group as
 select
     t.namespace as schemaname, t.item as object, pu.groname as groupname
-  , decode(charindex('r',split_part(split_part(array_to_string(t.relacl, '|'),pu.groname,2 ) ,'/',1)),0,false,true)  as sel
-  , decode(charindex('w',split_part(split_part(array_to_string(t.relacl, '|'),pu.groname,2 ) ,'/',1)),0,false,true)  as upd
-  , decode(charindex('a',split_part(split_part(array_to_string(t.relacl, '|'),pu.groname,2 ) ,'/',1)),0,false,true)  as ins
-  , decode(charindex('d',split_part(split_part(array_to_string(t.relacl, '|'),pu.groname,2 ) ,'/',1)),0,false,true)  as del
-  , decode(charindex('D',split_part(split_part(array_to_string(t.relacl, '|'),pu.groname,2 ) ,'/',1)),0,false,true)  as drp
-  , decode(charindex('R',split_part(split_part(array_to_string(t.relacl, '|'),pu.groname,2 ) ,'/',1)),0,false,true)  as ref
+  , decode(charindex('r',split_part(split_part(array_to_string(t.relacl, '|'), 'group '||pu.groname||'=',2 ) ,'/',1)),0,false,true)  as sel
+  , decode(charindex('w',split_part(split_part(array_to_string(t.relacl, '|'), 'group '||pu.groname||'=',2 ) ,'/',1)),0,false,true)  as upd
+  , decode(charindex('a',split_part(split_part(array_to_string(t.relacl, '|'), 'group '||pu.groname||'=',2 ) ,'/',1)),0,false,true)  as ins
+  , decode(charindex('d',split_part(split_part(array_to_string(t.relacl, '|'), 'group '||pu.groname||'=',2 ) ,'/',1)),0,false,true)  as del
+  , decode(charindex('D',split_part(split_part(array_to_string(t.relacl, '|'), 'group '||pu.groname||'=',2 ) ,'/',1)),0,false,true)  as drp
+  , decode(charindex('R',split_part(split_part(array_to_string(t.relacl, '|'), 'group '||pu.groname||'=',2 ) ,'/',1)),0,false,true)  as ref
 from
       (select
             use.usename as subject,
@@ -29,5 +29,4 @@ from
       where c.relowner = use.usesysid
       and nsp.nspname !~ '^information_schema|catalog_history|pg_'
       ) t
-join pg_group pu on array_to_string(t.relacl, '|') like '%'||pu.groname||'%'
-;
+join pg_group pu on array_to_string(t.relacl, '|') like '%group '||pu.groname||'=%';

--- a/src/AdminViews/v_get_tbl_priv_by_group.sql
+++ b/src/AdminViews/v_get_tbl_priv_by_group.sql
@@ -2,7 +2,7 @@
 Purpose: View to get the tables that a user group has access to
 History:
 2021-09-27 milindo Created
-2022-08-15 saeedma8 excluded system tables
+2023-03-13 amneet13 return results specific for groups.
 **********************************************************************************************/
 create or replace view admin.v_get_tbl_priv_by_group as
 select


### PR DESCRIPTION
*Issue #, if available:*
the view is returning wrong results

*Description of changes:*
For example if the `relacl` is 
`{test=arwdRxt/test,"group test_users=r/test","group test_users_rw=arwdRxt/test"}`

The existing code for group `test_users` will return the permission for both group that is of `test_users_ro` and `test_users`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
