### PR TITLE
adding a fix for pagination of log groups

### DIFF
--- a/src/SimpleReplay/helper/aws_service.py
+++ b/src/SimpleReplay/helper/aws_service.py
@@ -64,10 +64,9 @@ def cw_describe_log_groups(log_group_name=None, region=None):
             logGroupNamePrefix=log_group_name
         )
     else:
-        response_pg_1 = cloudwatch_client.describe_log_groups()
-        logs = response_pg_1
+        logs = cloudwatch_client.describe_log_groups()
 
-        token = response_pg_1.get('nextToken','')
+        token = logs.get('nextToken','')
         while token != '':
             response_itr = cloudwatch_client.describe_log_groups(nextToken=token)
             logs['logGroups'].extend(response_itr['logGroups'])

--- a/src/SimpleReplay/helper/aws_service.py
+++ b/src/SimpleReplay/helper/aws_service.py
@@ -64,7 +64,15 @@ def cw_describe_log_groups(log_group_name=None, region=None):
             logGroupNamePrefix=log_group_name
         )
     else:
-        return cloudwatch_client.describe_log_groups()
+        response_pg_1 = cloudwatch_client.describe_log_groups()
+        logs = response_pg_1
+
+        token = response_pg_1.get('nextToken','')
+        while token != '':
+            response_itr = cloudwatch_client.describe_log_groups(nextToken=token)
+            logs['logGroups'].extend(response_itr['logGroups'])
+            token = response_itr['nextToken'] if 'nextToken' in response_itr.keys() else ''
+    return logs
 
 
 def cw_describe_log_streams(log_group_name, region):


### PR DESCRIPTION
*Issue #, if available:*
The issue is since pagination was not included before in the code, the intended log group does not get picked and results in no logs found error.
*Description of changes:*
Added pagination to log groups so now all the log groups are retrieved.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
