### PR TITLE
[replay] Fix get secrets from AWS Secrets Manager

### DIFF
--- a/src/SimpleReplay/replay.py
+++ b/src/SimpleReplay/replay.py
@@ -1399,8 +1399,8 @@ def get_connection_credentials(username, database=None, max_attempts=10, skip_ca
                         time.sleep(retry_delay_sec)
                 else:
                     break
-            db_user = response['DbUser']
-            db_password = response['DbPassword']
+        db_user = response['DbUser']
+        db_password = response['DbPassword']
     else:
         rs_client = client("redshift", region_name=g_config.get("target_cluster_region", None), **additional_args)
         for attempt in range(1, max_attempts + 1):


### PR DESCRIPTION
When the secret id is selected, the code throws an expectation on the None value.

Make the DbUser and DbPassword available also when selecting the password from the AWS Secrets manager.

Error:
```
[INFO] 2023-04-11 15:22:25 Fetching secrets from: redshift_simple_replay_admin_credentials
Traceback (most recent call last):
  File "/home/ssm-user/amazon-redshift-utils/src/SimpleReplay/replay.py", line 1988, in <module>
    main()
  File "/home/ssm-user/amazon-redshift-utils/src/SimpleReplay/replay.py", line 1844, in main
    get_connection_credentials(connection_logs[0].username, database=connection_logs[0].database_name, max_attempts=1)
  File "/home/ssm-user/amazon-redshift-utils/src/SimpleReplay/replay.py", line 1450, in get_connection_credentials
    db_user.split(":")[1] if ":" in db_user else db_user,
TypeError: argument of type 'NoneType' is not iterable
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
