### PR TITLE
fixing error for workload location with trailing '/'

### DIFF
--- a/src/SimpleReplay/replay.py
+++ b/src/SimpleReplay/replay.py
@@ -862,7 +862,7 @@ def parse_copy_replacements(workload_directory):
     copy_replacements = {}
     copy_replacements_reader = None
 
-    replacements_path = workload_directory + "/" + g_copy_replacements_filename
+    replacements_path = workload_directory.rstrip("/") + "/" + g_copy_replacements_filename
 
     if replacements_path.startswith("s3://"):
         workload_s3_location = replacements_path[5:].partition("/")


### PR DESCRIPTION
*Description of changes:*

adding the "/" in the path in line 865 sometimes errors out when the customer gives a workload path with a trailing "/". 

The solution is to remove the trailing "/" and add just one "/" so the path remains valid.