### PR TITLE
Bugfix: add schema to join for column comments

### DIFF
--- a/src/AdminViews/v_generate_tbl_ddl.sql
+++ b/src/AdminViews/v_generate_tbl_ddl.sql
@@ -270,7 +270,7 @@ from (SELECT
   JOIN pg_class c ON c.oid = des.objoid
   JOIN pg_namespace n ON n.oid = c.relnamespace
   LEFT JOIN information_schema."columns" cl
-  ON cl.ordinal_position::integer = des.objsubid AND cl.table_name::NAME = c.relname
+  ON cl.ordinal_position::integer = des.objsubid AND cl.table_name::NAME = c.relname AND cl.table_schema = n.nspname
   WHERE c.relkind = 'r'
 
   UNION


### PR DESCRIPTION
*Issue #, if available:*
#707

*Description of changes:*
Add schema to the join condition when getting column comments to avoid getting column comments on table with same name from another schema

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
